### PR TITLE
fix: decouple LanceDB vector index from output_dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ All commands support `--force` to regenerate existing output files. Gemini-calli
 
 **Config:** `config.yaml` — channels, output directory, model, parallelism, per-channel prompt/since overrides.
 
+- `vector_db_dir` (optional): path for the LanceDB vector index. Defaults to `output_dir / .lancedb`. Must be on a real local filesystem — cloud-synced mounts (Google Drive File Stream, OneDrive, Dropbox) do not support the atomic file operations LanceDB needs to commit its MVCC manifests. The `index` command runs a pre-flight probe (`probe_atomic_writes`) that does a throwaway LanceDB connect + create + drop round-trip against the target path; if that round-trip fails, the command aborts with an actionable diagnostic *before* any Voyage embedding call, saving the user from paying for embeddings on a write that cannot succeed. The vector index is a derived artifact (rebuildable from transcripts via `index`), so it is safe to live in a local cache directory (e.g., `~/.cache/video-intel/lancedb`) outside a cloud-synced `output_dir`. See [ADR-0016](docs/adr/ADR-0016-vector-db-path-config.md).
+
 **Idempotency:** `is_processed()` checks for existing output files by `{date}-{slug}.{mode}.md` naming. Re-running scan safely skips already-processed videos. All commands support `--force` to regenerate.
 
 **Output goes to** `~/video-intel/{channel_name}/` (configurable via `output_dir`), not into this repo. Master `taxonomy.json` lives at the output root.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ directly.
 
 ```yaml
 output_dir: ~/video-intel
+vector_db_dir: ~/.cache/video-intel/lancedb  # optional; see note below
 default_since: 10d
 default_prompt: mindmap-light
 model: gemini-3-flash-preview
@@ -206,6 +207,7 @@ channels:
 | Field | Default | Description |
 | ----- | ------- | ----------- |
 | output_dir | ~/video-intel | Where output files are saved |
+| vector_db_dir | output_dir/.lancedb | LanceDB index location. Set this to a local path if `output_dir` is on a cloud-synced mount (Google Drive File Stream, OneDrive, Dropbox) - those filesystems do not support the atomic rename LanceDB needs. The `index` command runs a pre-flight probe and aborts with an actionable diagnostic before spending Voyage tokens if the path is incompatible. See [ADR-0016](docs/adr/ADR-0016-vector-db-path-config.md). |
 | default_since | 10d | Default lookback window |
 | default_prompt | mindmap-light | Default prompt for mind maps |
 | model | gemini-3-flash-preview | Gemini model (overridable via `--model` CLI flag) |

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,15 @@
 # Edit this file to add/remove channels and adjust settings.
 
 output_dir: ./video-intel
+
+# vector_db_dir: where the LanceDB vector index lives. Defaults to output_dir/.lancedb.
+# IMPORTANT: must be on a real local filesystem. Cloud-synced drives (Google Drive File
+# Stream, OneDrive, Dropbox) break LanceDB's MVCC commit with "Incorrect function"
+# (os error 1) on Windows. If output_dir is on one of those, uncomment the line below
+# and point it at a local cache directory. The index is derived (rebuildable via the
+# `index` command), so it is safe to live outside output_dir. See ADR-0016.
+# vector_db_dir: ~/.cache/video-intel/lancedb
+
 default_since: 10d
 default_prompt: mindmap-knowledge
 model: gemini-3-flash-preview

--- a/docs/adr/ADR-0016-vector-db-path-config.md
+++ b/docs/adr/ADR-0016-vector-db-path-config.md
@@ -143,16 +143,32 @@ LanceDB's own errors surface.
 
 - **One more config option** to document in `CLAUDE.md`, `README.md`, and
   `config.yaml.example` (when it exists).
-- **~100-300ms startup cost** on every `index` invocation. Probe does a
-  full LanceDB connect + create + drop round-trip. This is the correctness
-  tax for the integration-oracle approach; see "Why an integration probe"
-  above for why a cheaper mechanism probe was tried and rejected.
+- **Startup cost measured empirically on NTFS (2026-04-18, 5 runs in
+  fresh Python processes):** first call ~2.0s, warm calls ~20-30ms.
+  The first call is dominated by LanceDB's Rust init (Arrow imports,
+  tokio runtime spin-up). Because `build_search_index` calls
+  `lancedb.connect` and `create_table` regardless, this init tax would
+  be paid anyway; the probe only shifts it ~1.5s earlier. Incremental
+  cost of the probe itself (create_table + drop_table on a warm
+  process) is ~20-30ms. This is a trivial tax on a command that
+  typically runs for 1-2 minutes embedding thousands of chunks.
+- **Cleanup is best-effort, not guaranteed.** When the probe fails on
+  a broken filesystem, `shutil.rmtree(probe_dir, ignore_errors=True)`
+  may leave a partial `_probe_<hex>/` subdirectory if the OS refuses
+  to delete files LanceDB just wrote. The probe logs a debug message
+  when cleanup did not succeed, but does not raise. Fallout is
+  cosmetic (one more stranded dir on a path already known to be
+  broken) and the user is about to fix the underlying problem by
+  setting `vector_db_dir` anyway; automating more aggressive cleanup
+  is not worth the blast-radius risk.
 - **Probe is a near-perfect LanceDB oracle but still fallible**: false
   negatives (probe fails but LanceDB would succeed) remain theoretically
   possible on filesystems that behave differently for 1-row tables than
-  for full-sized ones. No such case has been observed. No opt-out flag
-  is added yet; if one appears, the user can point `vector_db_dir`
-  elsewhere.
+  for full-sized ones. No such case has been observed. The probe catches
+  every `Exception` subclass as a precaution against future LanceDB
+  versions introducing new exception types; a blanket catch is the right
+  call for a safety-net probe. No opt-out flag is added yet; if a false
+  negative appears, the user can point `vector_db_dir` elsewhere.
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-0016-vector-db-path-config.md
+++ b/docs/adr/ADR-0016-vector-db-path-config.md
@@ -1,0 +1,230 @@
+# Decouple LanceDB Vector Index Path from output_dir
+
+**Status:** accepted
+
+**Date:** 2026-04-18
+
+**Decision Maker(s):** Daniel Zivkovic
+
+## Context
+
+[ADR-0012](ADR-0012-vector-search-lancedb-voyage.md) introduced LanceDB as a
+file-based vector store, placed by default inside `output_dir/.lancedb`. At
+the time this was simply the path of least resistance: one config option
+(`output_dir`), one folder tree, one backup target. ADR-0012 describes the
+index as "file-based, no server, rebuildable from transcripts at any time."
+
+On 2026-04-18 the user moved `output_dir` from a local NTFS path to
+`G:/My Drive/video-intel/` (Google Drive File Stream). The full `scan`
+pipeline worked cleanly on the new path: mindmaps, transcripts, concept
+extraction, meta.json, and taxonomy.json all wrote correctly. The follow-up
+`index` command embedded all 5,294 transcript chunks successfully, then
+failed on the LanceDB write phase with:
+
+```text
+RuntimeError: lance error: LanceError(IO): Generic LocalFileSystem error:
+  Unable to copy file from ...\.lancedb\transcript_chunks.lance\_versions\
+    18446744073709551610.manifest-<uuid>
+    to ...\.lancedb\transcript_chunks.lance\_versions\
+    18446744073709551610.manifest:
+  Incorrect function. (os error 1)
+```
+
+Root cause: LanceDB uses MVCC and commits every write by atomically renaming
+a `{version}.manifest-<uuid>` staging file to `{version}.manifest`. Google
+Drive File Stream is a virtualized filesystem that proxies operations to the
+cloud; it handles read and write but rejects the specific atomic-rename call
+LanceDB needs with Windows `ERROR_INVALID_FUNCTION (os error 1)`. OneDrive
+and Dropbox mounts exhibit the same class of failure.
+
+Two concrete costs were paid in the incident:
+
+1. **Wasted embeddings.** Approximately $0.30 of Voyage `voyage-4-large`
+   tokens (5,294 chunks) embedded before the write failed. Every re-run
+   against the same broken path repeats the charge.
+2. **Transaction pollution.** The stranded `.manifest-<uuid>` staging file
+   remains on GDrive until manually cleaned up.
+
+The coupling lives at three call sites in `scripts/video_intel.py` where
+`output_dir / LANCEDB_DIR` is hardcoded. No ADR, `CLAUDE.md` carve-out, or
+test pins the index to that location - ADR-0012 explicitly calls it
+"rebuildable, delete and re-index at any time," which is the opposite of a
+durable-artifact invariant.
+
+## Decision
+
+Introduce `vector_db_dir` as an optional top-level config key in
+`config.yaml`, sibling to `output_dir`. Add a pre-flight atomic-rename probe
+to `build_search_index` that runs before any Voyage tokens are spent.
+
+### Precedence
+
+```text
+vector_db_dir resolution:
+  1. config.yaml `vector_db_dir` if set (tilde-expanded)
+  2. output_dir / LANCEDB_DIR (default - backwards compatible)
+```
+
+No CLI flag, no environment variable. Easy to add later if a concrete use
+case appears; YAGNI per agent-rules.md §1.
+
+### Probe design
+
+`probe_atomic_writes(path: Path) -> tuple[bool, str | None]` uses **LanceDB
+itself as the oracle**:
+
+1. `mkdir(parents=True, exist_ok=True)` on the target path.
+2. Connect LanceDB to a uuid-named throwaway subdir under the target.
+3. `create_table` a 1-row table, then `drop_table`.
+4. `shutil.rmtree(probe_dir, ignore_errors=True)` in `finally`.
+
+Returns `(True, None)` if the round-trip completes, `(False, reason)` if
+LanceDB raises `OSError` or `RuntimeError` (the latter wraps lance-table
+IO errors).
+
+### Why an integration probe, not a mechanism probe
+
+The initial design (plan rev 1) used a file-level mechanism probe:
+`os.replace` of a stdlib tempfile to a unique name, then later
+`os.replace`-over-existing after a rev 2 iteration. **Both iterations
+produced false negatives on Google Drive File Stream** during live smoke
+tests on 2026-04-18:
+
+- Rev 1 (`os.replace` to new name): probe passed, LanceDB still failed,
+  ~$0.30 of Voyage tokens wasted on the 5,294-chunk embed that was
+  discarded.
+- Rev 2 (`os.replace` over existing destination): probe passed again, same
+  failure, another ~$0.30 wasted.
+
+Root cause of the false negatives: the failure is inside LanceDB's Rust
+commit path (`lance-table-4.0.0/src/io/commit.rs:1046`) going through the
+`object_store` crate's `LocalFileSystem` implementation. The failing
+Windows call is in a different syscall family than Python's
+`os.replace`/`MoveFileExW` - the observed error says "Unable to **copy**
+file from ... to ..." which suggests an internal `fs::copy` or
+object-store-specific path, not a plain rename. GDFS tolerates
+Python-level `MoveFileExW` but rejects whatever LanceDB's Rust side
+calls.
+
+A mechanism probe is only predictive when the probe call and the real
+call share the same filesystem code path. Once we saw empirically that
+they do not, the only reliable oracle is LanceDB itself. The integration
+probe costs ~100-300ms per `index` invocation, which is a trivial tax
+compared to the ~$0.30 + 30s of embedding work it saves on a failed write.
+
+The regression guard `test_probe_uses_integration_oracle_not_mechanism_probe`
+asserts that `lancedb.connect` is called during the probe so a future
+"simplification" back to a mechanism probe fails loudly.
+
+### Probe placement
+
+Probe runs inside `build_search_index` before any `voyageai.Client()`
+construction. It does **not** run inside `hybrid_search` (the read path):
+reads do not hit the atomic-commit path, and a read-only search should work
+even on a slightly quirky filesystem. If the index itself is corrupt,
+LanceDB's own errors surface.
+
+## Consequences
+
+### Positive Consequences
+
+- **Zero wasted embeddings** on the next `index` run against an
+  incompatible filesystem. The probe catches the problem in ~10ms before
+  Voyage is ever called.
+- **Clear diagnostic** naming the failure mode (atomic rename), probable
+  cause (cloud sync), and concrete fix (a one-line config edit).
+- **Reinforces the "index is derived" invariant** from ADR-0012. Moving the
+  index off a synced path makes it even more clearly a derived local cache.
+- **Backwards compatible**: existing local installs with no `vector_db_dir`
+  set keep working. Default behavior is unchanged.
+- **No new dependencies**: `tempfile` and `uuid` are stdlib.
+
+### Negative Consequences
+
+- **One more config option** to document in `CLAUDE.md`, `README.md`, and
+  `config.yaml.example` (when it exists).
+- **~100-300ms startup cost** on every `index` invocation. Probe does a
+  full LanceDB connect + create + drop round-trip. This is the correctness
+  tax for the integration-oracle approach; see "Why an integration probe"
+  above for why a cheaper mechanism probe was tried and rejected.
+- **Probe is a near-perfect LanceDB oracle but still fallible**: false
+  negatives (probe fails but LanceDB would succeed) remain theoretically
+  possible on filesystems that behave differently for 1-row tables than
+  for full-sized ones. No such case has been observed. No opt-out flag
+  is added yet; if one appears, the user can point `vector_db_dir`
+  elsewhere.
+
+## Alternatives Considered
+
+- **File-level mechanism probe using `os.replace` (rev 1 and rev 2).**
+  - Pros: ~10ms cost, no LanceDB dependency during probing, pure stdlib.
+  - Cons: Empirically produces false negatives on GDrive File Stream.
+    Rev 1 (`os.replace` to new name) and rev 2 (`os.replace` over
+    existing destination) both let the probe pass while LanceDB's Rust
+    commit failed, wasting ~$0.30 of Voyage tokens per run. See "Why
+    an integration probe" above.
+  - **Status:** rejected after live smoke-test falsification.
+
+- **Detect GDFS by drive letter or mount type.**
+  - Pros: Zero-config for GDrive users on Windows.
+  - Cons: Fragile across OSes (different mount semantics on macOS/Linux),
+    does not cover OneDrive/Dropbox/Box without per-vendor heuristics, and
+    can still miss user-mounted network shares that behave identically.
+  - **Status:** rejected.
+
+- **Retry loop on rename failure.**
+  - Pros: Minimal code change. Familiar pattern.
+  - Cons: LanceDB's Rust side already retries internally. The failure is
+    deterministic on GDrive File Stream - more retries just burn more time
+    and do not change the outcome.
+  - **Status:** rejected.
+
+- **Switch LanceDB to a memory-backed store and persist as parquet.**
+  - Pros: Sidesteps the rename contract entirely.
+  - Cons: Loses MVCC benefits (consistent snapshots during concurrent
+    reads), larger change surface, different performance profile,
+    disk-layout migration for existing indices.
+  - **Status:** rejected.
+
+- **Hardcode `.cache/video-intel/lancedb` as the new default, drop
+  colocation entirely.**
+  - Pros: Simpler mental model (index always in user cache).
+  - Cons: Breaks existing local installs that expect the index next to the
+    data. Violates the "backwards compatible default" discipline.
+  - **Status:** rejected in favor of the config override approach.
+
+## Affects
+
+Source files changed by this decision:
+
+- `scripts/video_intel.py`:
+  - `resolve_vector_db_dir()` (new)
+  - `probe_atomic_writes()` (new)
+  - `build_search_index()` (accepts `config`, calls probe before Voyage)
+  - `hybrid_search()` (accepts `config`, uses resolver)
+  - `cmd_index()` / `cmd_search()` (pass `config` through)
+- `tests/test_vector_db_config.py` (new)
+- `CLAUDE.md` (Config section documents `vector_db_dir`)
+- `README.md` (if it enumerates config keys)
+
+## Related Debt
+
+- **Manual cleanup of the stranded `.lancedb/` on GDrive.** Documented in
+  the PR description, not automated. Automating filesystem deletes on a
+  cloud-synced path is the kind of blast-radius operation that belongs in
+  the user's hands.
+
+## Research References
+
+- [Plan: 2026-04-18-fix-decouple-lancedb-path-plan.md](../plans/2026-04-18-fix-decouple-lancedb-path-plan.md)
+- [ADR-0012: Vector Search via LanceDB + Voyage AI](ADR-0012-vector-search-lancedb-voyage.md)
+- [ADR-0013: Hybrid Search RRF Fusion](ADR-0013-hybrid-search-rrf-fusion.md)
+- [LanceDB commit.rs](https://github.com/lancedb/lance/blob/main/rust/lance-table/src/io/commit.rs) - the Rust side that emits the observed error.
+- [Microsoft Learn: MoveFileEx](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexa) - the underlying Win32 call `os.replace` uses on Windows, which GDFS rejects with `ERROR_INVALID_FUNCTION` (os error 1).
+
+## Notes
+
+This ADR reinforces rather than supersedes ADR-0012. The original decision
+("LanceDB, file-based, rebuildable") is still in force; ADR-0016 only
+clarifies that the *location* of those files is a user-tunable concern
+when the output_dir host cannot support LanceDB's atomic-commit contract.

--- a/docs/plans/2026-04-18-fix-decouple-lancedb-path-plan.md
+++ b/docs/plans/2026-04-18-fix-decouple-lancedb-path-plan.md
@@ -1,0 +1,433 @@
+---
+title: "fix: Decouple LanceDB vector index from Google-Drive-synced output_dir"
+type: fix
+status: active
+date: 2026-04-18
+branch: fix/lancedb-path-config
+---
+
+# fix: Decouple LanceDB vector index from Google-Drive-synced output_dir
+
+## Overview
+
+Introduce a separate `vector_db_dir` config option so the LanceDB vector index can live on a local filesystem even when `output_dir` is on a cloud-synced mount (Google Drive File Stream, OneDrive, Dropbox). Add a pre-flight probe that catches incompatible filesystems before any Voyage embedding tokens are spent. Record the decision in ADR-0016.
+
+## Problem Statement
+
+During this session we moved `output_dir` from a local NTFS path to `G:/My Drive/video-intel/` (Google Drive File Stream). The full `scan` pipeline worked cleanly on the new path (mindmaps, transcripts, concepts, meta.json, taxonomy.json all written correctly). The follow-up `index` command embedded all 5,294 transcript chunks successfully, but then the LanceDB write phase failed with:
+
+```text
+RuntimeError: lance error: LanceError(IO): Generic LocalFileSystem error:
+  Unable to copy file from ...\.lancedb\transcript_chunks.lance\_versions\18446744073709551610.manifest-<uuid>
+                       to ...\.lancedb\transcript_chunks.lance\_versions\18446744073709551610.manifest:
+  Incorrect function. (os error 1)
+```
+
+Root cause: LanceDB uses MVCC and commits every write by atomically renaming a `{version}.manifest-<uuid>` staging file to `{version}.manifest`. Google Drive File Stream is a virtualized filesystem that proxies operations to the cloud; it handles read and write but rejects the specific atomic-rename call LanceDB needs with Windows `ERROR_INVALID_FUNCTION (os error 1)`. OneDrive and Dropbox mounts exhibit the same class of failure.
+
+The current implementation at [scripts/video_intel.py:2314](scripts/video_intel.py#L2314), [:2400](scripts/video_intel.py#L2400), and [:2474](scripts/video_intel.py#L2474) hardcodes the LanceDB path as `output_dir / LANCEDB_DIR`, forcing the vector index to live alongside the durable artifacts. That coupling is not architecturally required: ADR-0012 explicitly calls the index "rebuildable, delete and re-index at any time." It lives there today because it was the simplest default, not because anything depends on it.
+
+The user impact today: anyone running `index` against a cloud-synced `output_dir` pays the full Voyage embedding cost (approximately $0.30 for our corpus at the `voyage-4-large` price point) before discovering the write fails. The stranded `.manifest-<uuid>` staging file remains on GDrive as transaction pollution until manually cleaned up.
+
+## Proposed Solution
+
+Three-part change:
+
+1. **New config option `vector_db_dir`** at the top level of `config.yaml`, sibling to `output_dir`. Tilde-expanded like `output_dir`. Defaults to `output_dir / .lancedb` so existing local installs keep working without a config edit.
+
+2. **Pre-flight probe** that tests whether the target path supports atomic rename before the `index` command spends any Voyage tokens. Runs in ~10ms. On failure, emits a diagnostic that names the likely cause (cloud-synced filesystem) and shows the fix (set `vector_db_dir` to a local path).
+
+3. **ADR-0016** recording the decision and the concrete incident that justified it. Updates to `CLAUDE.md` and `README.md` to document the new option.
+
+## Technical Considerations
+
+### Boundary check (specs/agent-rules.md §5)
+
+Before crossing the "vector index lives under output_dir" boundary:
+
+- (a) `git log --follow` the enforcement point: the coupling was introduced in the vector-search commit that also produced ADR-0012. No ADR or CLAUDE.md carve-out pins it there; ADR-0012 treats the path as an implementation detail.
+- (b) No existing ADR forbids separating the paths.
+- (c) CLAUDE.md's "Config:" section does not mention vector_db_dir yet; the new option slots in naturally.
+
+Verdict: safe to cross. The new ADR-0016 documents the carve-out.
+
+### Precedence model
+
+Mirrors the existing `model` precedence documented in CLAUDE.md (CLI flag > config.yaml > default constant), minus the CLI flag for this first cut:
+
+```text
+vector_db_dir resolution:
+  1. config.yaml `vector_db_dir` if set
+  2. output_dir / .lancedb (default, backwards compatible)
+```
+
+CLI override (`--vector-db-dir`) and environment variable (`VIDEO_INTEL_VECTOR_DB_DIR`) are deliberately **not** added in this change. YAGNI per §1 of agent-rules.md. Easy to add later if a concrete use case appears.
+
+### Probe design
+
+```python
+def probe_atomic_writes(path: Path) -> tuple[bool, str | None]:
+    """Return (ok, reason). On ok=False, reason is a user-facing diagnostic."""
+```
+
+Implementation: inside a single `try` block, `mkdir` the target, create a uniquely named probe file via `tempfile.NamedTemporaryFile(dir=path, delete=False)`, `os.replace()` it to a second unique name, delete both. Clean up probe files in a `finally` block on every path (success and failure) so a crash or an unexpected OSError does not leave litter.
+
+Correctness note: `os.replace()` on Python maps to `MoveFileExW(..., REPLACE_EXISTING)` on Windows and `rename(2)` on POSIX. Rust's `std::fs::rename` (what LanceDB's Rust side calls) maps to `rename(2)` on POSIX and to `MoveFileExW` with a `SetFileInformationByHandle` fallback on Windows. The two calls are in the same family and fail identically on Google Drive File Stream in practice, so the probe is a strong signal for our target failure mode, not a perfect mirror. A passing probe does not guarantee a LanceDB commit will succeed on pathological filesystems; a failing probe reliably identifies the class of filesystem that broke us on 2026-04-18.
+
+Why unique filenames (tempfile over fixed `.probe` / `.probe.tmp`): two parallel `index` invocations in the same directory would collide on fixed names and produce a spurious probe failure. We do not run parallel indexes today and there is no lockfile to prevent it, but uniqueness is effectively free (one extra import) and removes a theoretical false negative.
+
+Why `mkdir` inside the `try`: a target whose parent is not writable would otherwise escape as a raw `PermissionError` traceback rather than returning the actionable diagnostic. Putting the `mkdir` inside the same `try` that wraps the probe converts that failure into the same friendly error path.
+
+### Error message shape
+
+```text
+ERROR: Cannot use vector_db_dir=<path>
+  Atomic rename failed: <OSError detail>
+
+  LanceDB requires atomic rename to commit its MVCC manifests. This usually
+  means the path is on a cloud-synced filesystem (Google Drive File Stream,
+  OneDrive, Dropbox). Those mounts do not support the atomic file operations
+  LanceDB needs.
+
+  Fix: set vector_db_dir to a local path in config.yaml, for example:
+    vector_db_dir: ~/.cache/video-intel/lancedb
+
+  The index is derived and rebuildable, so it is safe to live outside your
+  synced output_dir.
+```
+
+The message names the failure mode (atomic rename), the probable cause (cloud sync), and the concrete fix (a config edit). That matches agent-rules.md meta-rule: "Every new rule must name the failure mode it prevents."
+
+### Migration for existing users
+
+- Local users (output_dir on NTFS/ext4/APFS): no action. Default behavior unchanged. Probe passes. Existing `.lancedb/` under `output_dir` keeps working.
+- Cloud-sync users (output_dir on GDFS/OneDrive/Dropbox): set `vector_db_dir` in `config.yaml`, run `python scripts/video_intel.py index` once to rebuild. The old stranded `.lancedb/` directory under the synced output_dir can be manually deleted to reclaim space (documented in the plan and the PR description, not automated).
+
+### Dependency on ADR-0012
+
+ADR-0012 calls the LanceDB index "file-based, rebuildable from transcripts at any time." This change reinforces that property rather than violating it: moving the index off the synced path makes it even more clearly a derived local cache. No ADR-0012 amendment is required; ADR-0016 supersedes the colocation assumption.
+
+## Acceptance Criteria
+
+### Functional
+
+- [x] `config.yaml` supports an optional `vector_db_dir` key at the top level.
+- [x] When `vector_db_dir` is unset, `index` and `search --vector` behave identically to today (same path, same outputs).
+- [x] When `vector_db_dir` is set, both commands read and write from the configured path (with tilde expansion).
+- [x] Running `index` against a path that fails the atomic-rename probe aborts **before** calling Voyage, prints the actionable diagnostic, and exits non-zero.
+- [x] Running `index` against a path that passes the probe completes the full embed and write sequence. *(verified 2026-04-18: 5294 chunks embedded + committed to local cache path in 1m 51s, then `search --vector "permission problems"` returned 10 ranked hits.)*
+
+### Documentation
+
+- [x] ADR-0016 committed under `docs/adr/` following the existing template.
+- [x] CLAUDE.md "Config:" section lists `vector_db_dir` and the probe behavior.
+- [x] README.md (if it currently documents config keys) lists `vector_db_dir`.
+
+### Testing (pytest -m "not integration")
+
+- [x] `test_resolve_vector_db_dir_defaults_to_output_dir_lancedb`
+- [x] `test_resolve_vector_db_dir_config_override_wins`
+- [x] `test_resolve_vector_db_dir_expands_tilde`
+- [x] `test_probe_atomic_writes_succeeds_on_writable_dir` (uses `tmp_path`, asserts no litter)
+- [x] `test_probe_atomic_writes_returns_reason_on_rename_failure` (monkeypatches `os.replace` to raise `OSError`, asserts no litter)
+- [x] `test_build_search_index_aborts_before_voyage_when_probe_fails` (wiring test: monkeypatches `probe_atomic_writes` to return `(False, "...")`, asserts `SystemExit` raised and the `voyageai.Client` is never instantiated)
+
+### Code quality
+
+- [x] `ruff format . && ruff check . --fix` clean.
+- [x] All added functions carry type hints.
+- [x] No new CLI flags, env vars, or imports beyond what the above requires. *(added: `contextlib`, `tempfile`, `uuid` — all stdlib, required by probe)*
+
+## Success Metrics
+
+- Zero Voyage tokens wasted on the next `index` run against the current `G:/My Drive/video-intel` output_dir: the probe catches the incompatibility before embedding starts.
+- One-command recovery: after the user adds `vector_db_dir: ~/.cache/video-intel/lancedb` to config.yaml, `index` succeeds and `search --vector "permission problems"` returns results.
+
+## Dependencies and Risks
+
+### Dependencies
+
+- None. The change is local to `scripts/video_intel.py`, `config.yaml` schema (documented, not enforced), and docs.
+
+### Risks
+
+- **Probe false positive (path passes probe but LanceDB still fails):** mitigated by using `os.replace` which is exactly the call LanceDB's Rust side uses on Windows. If this happens in practice, the LanceDB error message still reaches the user and points at the path.
+- **Probe false negative (path fails probe but LanceDB would succeed):** possible in niche filesystems. Mitigated by keeping the probe failure message actionable - the user can investigate and override. We do not add an opt-out flag yet because no such case is known.
+- **Existing users on cloud-synced output_dir with a working local-build `.lancedb/`:** this situation does not exist in practice. If it did, the probe would pass on the old local path and the user could set `vector_db_dir` to point at it.
+
+## Implementation Plan
+
+Sequential, one file at a time (per agent-rules.md §4 "Execution strategy: sequential for coupled changes").
+
+### Step 1: Branch and baseline
+
+```bash
+git checkout -b fix/lancedb-path-config
+ruff format . && ruff check . --fix && pytest -m "not integration" -q
+```
+
+Confirm green baseline before any code change.
+
+### Step 2: Write tests first (TDD RED)
+
+New test file: `tests/test_vector_db_config.py`
+
+```python
+# tests/test_vector_db_config.py
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.video_intel import probe_atomic_writes, resolve_vector_db_dir
+
+
+def test_resolve_vector_db_dir_defaults_to_output_dir_lancedb(tmp_path):
+    out = tmp_path / "out"
+    config = {"output_dir": str(out)}
+    assert resolve_vector_db_dir(config, out) == out / ".lancedb"
+
+
+def test_resolve_vector_db_dir_config_override_wins(tmp_path):
+    out = tmp_path / "out"
+    local = tmp_path / "cache" / "db"
+    config = {"output_dir": str(out), "vector_db_dir": str(local)}
+    assert resolve_vector_db_dir(config, out) == local
+
+
+def test_resolve_vector_db_dir_expands_tilde(tmp_path):
+    config = {"vector_db_dir": "~/cache/db"}
+    result = resolve_vector_db_dir(config, tmp_path / "out")
+    assert "~" not in str(result)
+    assert result.is_absolute()
+
+
+def test_probe_atomic_writes_succeeds_on_writable_dir(tmp_path):
+    target = tmp_path / "probe"
+    ok, reason = probe_atomic_writes(target)
+    assert ok is True
+    assert reason is None
+    assert not any(target.glob(".probe*"))  # no litter on success
+
+
+def test_probe_atomic_writes_returns_reason_on_rename_failure(tmp_path, monkeypatch):
+    def boom(src, dst):
+        raise OSError(1, "Incorrect function")
+    monkeypatch.setattr("scripts.video_intel.os.replace", boom)
+    target = tmp_path / "probe"
+    ok, reason = probe_atomic_writes(target)
+    assert ok is False
+    assert "atomic" in reason.lower() or "rename" in reason.lower()
+    assert "vector_db_dir" in reason
+    assert not any(target.glob(".probe*"))  # no litter on failure either
+
+
+def test_build_search_index_aborts_before_voyage_when_probe_fails(tmp_path, monkeypatch):
+    """Wiring test: probe failure short-circuits before any Voyage client is built."""
+    from scripts import video_intel as vi
+
+    bad_path = tmp_path / "bad"
+    config = {"output_dir": str(tmp_path / "out"), "vector_db_dir": str(bad_path)}
+
+    monkeypatch.setattr(vi, "probe_atomic_writes", lambda p: (False, "simulated failure"))
+
+    sentinel = {"voyage_called": False}
+    class _ShouldNotBeConstructed:
+        def __init__(self, *a, **kw):
+            sentinel["voyage_called"] = True
+            raise AssertionError("Voyage client built despite probe failure")
+    monkeypatch.setattr(vi.voyageai, "Client", _ShouldNotBeConstructed, raising=False)
+    monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+
+    with pytest.raises(SystemExit):
+        vi.build_search_index(Path(config["output_dir"]), config=config)
+
+    assert sentinel["voyage_called"] is False
+```
+
+Note on monkeypatch targets: use the fully qualified name `scripts.video_intel.os.replace` rather than the global `os.replace`, so the patch reaches the module-level `os` import inside `video_intel.py` and not just the test module's reference.
+
+Run `pytest tests/test_vector_db_config.py -v` and confirm all five tests fail with `ImportError` (functions do not exist yet).
+
+### Step 3: Implement the resolver and probe (TDD GREEN)
+
+Edit [scripts/video_intel.py](scripts/video_intel.py), near the existing `resolve_output_dir` at line 62:
+
+```python
+# scripts/video_intel.py (new functions, near line 62)
+
+def resolve_vector_db_dir(config: dict, output_dir: Path) -> Path:
+    """Resolve vector index location. Config override > output_dir/.lancedb default."""
+    override = config.get("vector_db_dir")
+    if override:
+        return Path(override).expanduser()
+    return output_dir / LANCEDB_DIR
+
+
+def probe_atomic_writes(path: Path) -> tuple[bool, str | None]:
+    """Probe whether atomic rename works at `path`. LanceDB needs this to commit.
+
+    Returns (True, None) on success, (False, reason) on failure. Cleans up its probe files
+    on every exit path so a crash mid-probe never leaves litter.
+    """
+    src: Path | None = None
+    dst: Path | None = None
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=path, prefix=".probe_src_", suffix=".tmp", delete=False
+        ) as f:
+            f.write("probe")
+            src = Path(f.name)
+        dst = path / f".probe_dst_{uuid.uuid4().hex}.tmp"
+        os.replace(src, dst)
+        src = None  # os.replace consumed the source
+        return True, None
+    except OSError as e:
+        reason = (
+            f"Atomic rename failed: {e}. LanceDB requires atomic file operations "
+            f"to commit MVCC manifests. This usually means the path is on a "
+            f"cloud-synced filesystem (Google Drive File Stream, OneDrive, Dropbox). "
+            f"Set vector_db_dir in config.yaml to a local path."
+        )
+        return False, reason
+    finally:
+        for leftover in (src, dst):
+            if leftover is not None and leftover.exists():
+                try:
+                    leftover.unlink()
+                except OSError:
+                    pass
+```
+
+New imports required at top of `scripts/video_intel.py`: `tempfile`, `uuid`. Both are stdlib.
+
+Run `pytest tests/test_vector_db_config.py -v` and confirm all five tests pass.
+
+### Step 4: Wire the resolver into call sites
+
+Three hardcoded references to replace:
+
+- [scripts/video_intel.py:2314](scripts/video_intel.py#L2314) inside `build_search_index`
+- [scripts/video_intel.py:2400](scripts/video_intel.py#L2400) inside `hybrid_search`
+- [scripts/video_intel.py:2474](scripts/video_intel.py#L2474) inside `cmd_index` (status print)
+
+Both `build_search_index` and `hybrid_search` currently take `output_dir` only. Change them to also accept `config: dict` (or pass the resolved `db_path` in from the caller). The simpler surgery is to pass `config` through; the caller (`cmd_index`, `cmd_search`) already holds it.
+
+Inside `build_search_index`, after computing `db_path`, call the probe:
+
+```python
+# scripts/video_intel.py, inside build_search_index, after db_path is resolved
+db_path = resolve_vector_db_dir(config, output_dir)
+ok, reason = probe_atomic_writes(db_path)
+if not ok:
+    log.error("Cannot use vector_db_dir=%s", db_path)
+    log.error("%s", reason)
+    sys.exit(1)
+db = lancedb.connect(str(db_path))
+```
+
+Do NOT run the probe inside `hybrid_search`: reads do not hit the atomic-commit path, and we want read-only search to work even on a slightly quirky filesystem. If the index is corrupt, LanceDB's own errors will surface.
+
+### Step 5: Write ADR-0016
+
+New file: `docs/adr/ADR-0016-vector-db-path-config.md`
+
+Follow the template at [docs/adr/template.md](docs/adr/template.md). Sections:
+
+- **Status:** accepted
+- **Date:** 2026-04-18
+- **Context:** the incident (4/18 session, 5,294 chunks embedded then write failed on GDFS, $0.30 wasted). LanceDB's atomic-commit contract. Why atomic rename fails on cloud-synced mounts.
+- **Decision:** separate `vector_db_dir` config option with pre-flight probe. Default preserves backwards compatibility.
+- **Consequences:** positive (no more wasted embeddings, cloud-sync users unblocked, stronger "index is derived" invariant), negative (one more config option to document, a ~10ms startup cost on `index`).
+- **Alternatives considered:** detect GDFS by drive letter (fragile, cross-platform mess); retry loop on rename failure (LanceDB already retries, the failure is deterministic); use `lancedb.connect(uri="memory://")` and persist as parquet (larger change, loses MVCC benefits).
+- **Affects:** scripts/video_intel.py, config.yaml schema docs, CLAUDE.md, README.md.
+
+### Step 6: Update CLAUDE.md
+
+Append to the "Config:" bullet in the Architecture section:
+
+```markdown
+- `vector_db_dir` (optional): path for the LanceDB vector index. Defaults to
+  `output_dir / .lancedb`. Must be on a real local filesystem. Cloud-synced
+  mounts (Google Drive File Stream, OneDrive, Dropbox) do not support the
+  atomic file operations LanceDB needs to commit MVCC manifests. The `index`
+  command runs a pre-flight probe and aborts with a clear diagnostic if the
+  configured path cannot support atomic rename. The vector index is a derived
+  artifact (rebuildable from transcripts via `index`), so it is safe to live
+  in a local cache directory (e.g., `~/.cache/video-intel/lancedb`) outside
+  your synced `output_dir`.
+```
+
+### Step 7: Update README.md (if applicable)
+
+Check whether README.md documents config keys today. If yes, add `vector_db_dir` with the same shape as the CLAUDE.md entry but trimmed to user-facing prose. If README.md only covers quickstart and does not enumerate config, no change needed.
+
+### Step 8: Green-bar validation
+
+```bash
+ruff format . && ruff check . --fix && pytest -m "not integration" -q
+```
+
+Must pass before opening the PR.
+
+### Step 9: Live smoke test
+
+With the current broken state on G: still in place:
+
+```bash
+# Set vector_db_dir in config.yaml to a local path
+# Example: vector_db_dir: C:/Users/danie/video-intel-cache/lancedb
+
+python scripts/video_intel.py index
+# Expect: probe passes, 5294 chunks embed and index cleanly
+
+python scripts/video_intel.py search "permission problems" --vector
+# Expect: top-k hits returned
+
+# Then flip config back to an intentionally bad path and re-run index
+# Example: vector_db_dir: "G:/My Drive/video-intel/.lancedb"
+python scripts/video_intel.py index
+# Expect: probe fails, clear diagnostic, non-zero exit, ZERO Voyage tokens spent
+```
+
+### Step 10: PR
+
+- Branch: `fix/lancedb-path-config`
+- PR title: `fix: Decouple LanceDB vector index from output_dir`
+- PR body: links to this plan and ADR-0016, summarizes the incident, lists the acceptance criteria.
+- Do NOT push straight to `main` per the user's workflow memory.
+- Do NOT commit unless explicitly asked (per agent-rules.md §4).
+
+### Manual cleanup (documented in PR description, not automated)
+
+Once the PR is merged and the user has rebuilt against a local `vector_db_dir`:
+
+```bash
+# One-time: reclaim GDrive space taken by the stranded .lancedb directory
+rm -rf "G:/My Drive/video-intel/.lancedb/"
+```
+
+This step is manual because automating filesystem deletes on a synced cloud path is the kind of blast-radius operation the harness rules ask us to keep in the user's hands.
+
+## References
+
+### Internal
+
+- ADR-0012: [docs/adr/ADR-0012-vector-search-lancedb-voyage.md](docs/adr/ADR-0012-vector-search-lancedb-voyage.md) - original vector-search decision, establishes "index is derived, rebuildable"
+- ADR-0013: [docs/adr/ADR-0013-hybrid-search-rrf-fusion.md](docs/adr/ADR-0013-hybrid-search-rrf-fusion.md) - hybrid search layer that reads the same index
+- CLAUDE.md: "Config:" section - documents existing `output_dir`, `model`, `max_parallel`, `auto_concepts`
+- specs/agent-rules.md §5: architectural boundary checklist (applied above)
+- scripts/video_intel.py:[62](scripts/video_intel.py#L62) - `resolve_output_dir` pattern this change mirrors
+- scripts/video_intel.py:[2153](scripts/video_intel.py#L2153) - `LANCEDB_DIR` constant (kept as the default suffix)
+- scripts/video_intel.py:[2314](scripts/video_intel.py#L2314), [2400](scripts/video_intel.py#L2400), [2474](scripts/video_intel.py#L2474) - three call sites to update
+
+### External
+
+- [LanceDB commit.rs source](https://github.com/lancedb/lance/blob/main/rust/lance-table/src/io/commit.rs) - the Rust code that emitted the failure we hit (line 1046 in the error message)
+- [LanceDB GitHub issue #1847 (search for rename failure)](https://github.com/lancedb/lancedb/issues) - class of known cloud-sync filesystem incompatibilities
+- [Microsoft Learn: MoveFileEx MOVEFILE_REPLACE_EXISTING](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexa) - the underlying Win32 call `os.replace` uses, which GDFS rejects with `ERROR_INVALID_FUNCTION` (os error 1)
+
+### Session context
+
+This plan comes out of the 2026-04-18 session where the user moved `output_dir` from a local path to `G:/My Drive/video-intel/`. The full scan and concept back-fill succeeded on the new path; only the `index` command broke. The incident log and stranded manifest file served as ground truth for the failure mode described above.

--- a/scripts/video_intel.py
+++ b/scripts/video_intel.py
@@ -17,8 +17,10 @@ import logging
 import os
 import random
 import re
+import shutil
 import sys
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from html import unescape
@@ -65,6 +67,59 @@ def resolve_output_dir(config):
         output_dir = SKILL_DIR / output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
+
+
+def resolve_vector_db_dir(config: dict[str, Any], output_dir: Path) -> Path:
+    """Resolve the LanceDB vector index location.
+
+    Precedence: config.yaml `vector_db_dir` (tilde-expanded) > output_dir / LANCEDB_DIR.
+    See ADR-0016 for why the index may need to live outside a cloud-synced output_dir.
+    """
+    override = config.get("vector_db_dir")
+    if override:
+        return Path(override).expanduser()
+    return output_dir / LANCEDB_DIR
+
+
+def probe_atomic_writes(path: Path) -> tuple[bool, str | None]:
+    """Probe whether LanceDB can commit at `path` by doing a tiny round-trip.
+
+    Returns (True, None) on success, (False, reason) on failure. Best-effort
+    cleans up the probe subdir on every exit path.
+
+    Why integration probe, not file-level probe: empirically (2026-04-18 smoke
+    test, two iterations) Google Drive File Stream permits Python-level
+    `os.replace` - including rename-over-existing - but still fails LanceDB's
+    Rust-side commit with `ERROR_INVALID_FUNCTION (os error 1)`. The failing
+    call is inside `lance-table/src/io/commit.rs` and uses object_store's
+    LocalFileSystem copy/rename path, which is a different Windows syscall
+    family than Python's. Mechanism probes that mimic the syscall all produce
+    false negatives on GDFS. The only reliable oracle is LanceDB itself, so
+    the probe creates a throwaway 1-row table in a sibling subdir and catches
+    whatever LanceDB raises. See ADR-0016.
+
+    Cost: ~100-300ms per call. Acceptable tax for catching the failure before
+    paying Voyage embedding tokens.
+    """
+    lancedb = require_lancedb()
+    probe_dir = path / f"_probe_{uuid.uuid4().hex[:12]}"
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        db = lancedb.connect(str(probe_dir))
+        db.create_table("probe", data=[{"v": 1}], mode="overwrite")
+        db.drop_table("probe")
+        return True, None
+    except (OSError, RuntimeError) as e:
+        reason = (
+            f"LanceDB commit failed at probe: {e}. This usually means the path is "
+            f"on a cloud-synced filesystem (Google Drive File Stream, OneDrive, "
+            f"Dropbox) that does not support the atomic file operations LanceDB's "
+            f"MVCC commit path requires. Set vector_db_dir in config.yaml to a "
+            f"local path."
+        )
+        return False, reason
+    finally:
+        shutil.rmtree(probe_dir, ignore_errors=True)
 
 
 def resolve_model(args: argparse.Namespace, config: dict[str, Any]) -> str:
@@ -2297,7 +2352,13 @@ def _embed_batch(vo_client, texts: list[str], model: str, input_type: str) -> li
     return all_embeddings
 
 
-def build_search_index(output_dir: Path, *, channel_filter: str | None = None, force: bool = False) -> int:
+def build_search_index(
+    output_dir: Path,
+    *,
+    channel_filter: str | None = None,
+    force: bool = False,
+    config: dict[str, Any] | None = None,
+) -> int:
     """Build or rebuild the LanceDB vector index from transcripts + concepts.
 
     Returns the number of chunks indexed.
@@ -2310,9 +2371,15 @@ def build_search_index(output_dir: Path, *, channel_filter: str | None = None, f
         log.error("VOYAGE_API_KEY not set. Sign up free at https://dash.voyageai.com/")
         sys.exit(1)
 
+    db_path = resolve_vector_db_dir(config or {}, output_dir)
+    ok, reason = probe_atomic_writes(db_path)
+    if not ok:
+        log.error("Cannot use vector_db_dir=%s", db_path)
+        log.error("%s", reason)
+        sys.exit(1)
+
     vo = voyageai.Client()
-    db_path = str(output_dir / LANCEDB_DIR)
-    db = lancedb.connect(db_path)
+    db = lancedb.connect(str(db_path))
 
     # Drop existing table if force rebuild
     if force and LANCEDB_TABLE in db.list_tables().tables:
@@ -2384,6 +2451,7 @@ def hybrid_search(
     *,
     channel_filter: str | None = None,
     limit: int = 10,
+    config: dict[str, Any] | None = None,
 ) -> list[dict]:
     """Search the LanceDB index with hybrid BM25 + vector + RRF fusion.
 
@@ -2397,8 +2465,8 @@ def hybrid_search(
         log.error("VOYAGE_API_KEY not set. Sign up free at https://dash.voyageai.com/")
         sys.exit(1)
 
-    db_path = str(output_dir / LANCEDB_DIR)
-    db = lancedb.connect(db_path)
+    db_path = resolve_vector_db_dir(config or {}, output_dir)
+    db = lancedb.connect(str(db_path))
 
     if LANCEDB_TABLE not in db.list_tables().tables:
         log.error("Search index not found. Run: video_intel.py index")
@@ -2463,7 +2531,7 @@ def cmd_index(args, config):
     """Build or rebuild the vector search index."""
     output_dir = resolve_output_dir(config)
     t0 = time.time()
-    count = build_search_index(output_dir, channel_filter=args.channel, force=args.force)
+    count = build_search_index(output_dir, channel_filter=args.channel, force=args.force, config=config)
     elapsed = time.time() - t0
 
     if count == 0:
@@ -2471,7 +2539,7 @@ def cmd_index(args, config):
     else:
         mins, secs = divmod(int(elapsed), 60)
         print(f"Indexed {count} chunks in {mins}m {secs:02d}s.")
-        print(f"  Index: {output_dir / LANCEDB_DIR}")
+        print(f"  Index: {resolve_vector_db_dir(config, output_dir)}")
         print("  Run 'search --vector \"query\"' to search.")
 
 
@@ -2584,7 +2652,7 @@ def cmd_search(args, config):
 
     # Hybrid search mode (BM25 + vector + RRF)
     if getattr(args, "vector", False):
-        hits = hybrid_search(output_dir, args.query, channel_filter=args.channel, limit=args.limit)
+        hits = hybrid_search(output_dir, args.query, channel_filter=args.channel, limit=args.limit, config=config)
         if not hits:
             print(f'No results for "{args.query}". Is the index built? Run: video_intel.py index')
             return

--- a/scripts/video_intel.py
+++ b/scripts/video_intel.py
@@ -98,8 +98,11 @@ def probe_atomic_writes(path: Path) -> tuple[bool, str | None]:
     the probe creates a throwaway 1-row table in a sibling subdir and catches
     whatever LanceDB raises. See ADR-0016.
 
-    Cost: ~100-300ms per call. Acceptable tax for catching the failure before
-    paying Voyage embedding tokens.
+    Cost (measured on NTFS, 5 runs): ~2s on first call in a fresh process
+    (dominated by LanceDB's Rust init, which `build_search_index` would pay
+    anyway on its own `connect`+`create_table`), ~20-30ms on warm calls.
+    Trivial tax for catching the failure before paying Voyage embedding
+    tokens.
     """
     lancedb = require_lancedb()
     probe_dir = path / f"_probe_{uuid.uuid4().hex[:12]}"
@@ -109,7 +112,9 @@ def probe_atomic_writes(path: Path) -> tuple[bool, str | None]:
         db.create_table("probe", data=[{"v": 1}], mode="overwrite")
         db.drop_table("probe")
         return True, None
-    except (OSError, RuntimeError) as e:
+    except Exception as e:
+        # Blanket catch is deliberate - see docstring. Probe is a safety net; any
+        # failure here means the path is unusable, regardless of LanceDB's exception taxonomy.
         reason = (
             f"LanceDB commit failed at probe: {e}. This usually means the path is "
             f"on a cloud-synced filesystem (Google Drive File Stream, OneDrive, "
@@ -120,6 +125,8 @@ def probe_atomic_writes(path: Path) -> tuple[bool, str | None]:
         return False, reason
     finally:
         shutil.rmtree(probe_dir, ignore_errors=True)
+        if probe_dir.exists():
+            log.debug("probe cleanup could not remove %s; residual files may remain", probe_dir)
 
 
 def resolve_model(args: argparse.Namespace, config: dict[str, Any]) -> str:
@@ -2466,6 +2473,8 @@ def hybrid_search(
         sys.exit(1)
 
     db_path = resolve_vector_db_dir(config or {}, output_dir)
+    # No probe here: search is read-only and does not exercise LanceDB's commit path.
+    # The probe lives in build_search_index where it prevents wasted Voyage embeddings.
     db = lancedb.connect(str(db_path))
 
     if LANCEDB_TABLE not in db.list_tables().tables:

--- a/tests/test_vector_db_config.py
+++ b/tests/test_vector_db_config.py
@@ -1,0 +1,139 @@
+"""Tests for vector_db_dir resolution and the LanceDB-oracle probe.
+
+Guards two failure modes:
+  1. The LanceDB path silently colocating with a cloud-synced output_dir
+     (as in the 2026-04-18 GDrive File Stream incident - see ADR-0016).
+  2. build_search_index wasting Voyage tokens before the probe catches an
+     incompatible filesystem.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from video_intel import probe_atomic_writes, resolve_vector_db_dir
+
+
+def test_resolve_vector_db_dir_defaults_to_output_dir_lancedb(tmp_path):
+    out = tmp_path / "out"
+    config = {"output_dir": str(out)}
+    assert resolve_vector_db_dir(config, out) == out / ".lancedb"
+
+
+def test_resolve_vector_db_dir_config_override_wins(tmp_path):
+    out = tmp_path / "out"
+    local = tmp_path / "cache" / "db"
+    config = {"output_dir": str(out), "vector_db_dir": str(local)}
+    assert resolve_vector_db_dir(config, out) == local
+
+
+def test_resolve_vector_db_dir_expands_tilde(tmp_path):
+    config = {"vector_db_dir": "~/cache/db"}
+    result = resolve_vector_db_dir(config, tmp_path / "out")
+    assert "~" not in str(result)
+    assert result.is_absolute()
+
+
+def test_probe_atomic_writes_succeeds_on_writable_dir(tmp_path):
+    """Real LanceDB round-trip against a local tmp_path must succeed."""
+    target = tmp_path / "probe_target"
+    ok, reason = probe_atomic_writes(target)
+    assert ok is True
+    assert reason is None
+    assert not list(target.glob("_probe_*"))  # probe subdir cleaned up
+
+
+def test_probe_atomic_writes_returns_reason_on_lancedb_commit_failure(tmp_path, monkeypatch):
+    """When LanceDB create_table raises (the actual GDFS failure shape), probe
+    returns (False, reason). The reason names vector_db_dir as the fix."""
+    import video_intel as vi
+
+    class _FakeDB:
+        def create_table(self, *a, **kw):
+            raise RuntimeError("lance error: Incorrect function. (os error 1)")
+
+        def drop_table(self, *a, **kw):
+            pass
+
+    fake_lancedb = SimpleNamespace(connect=lambda *a, **kw: _FakeDB())
+    monkeypatch.setattr(vi, "require_lancedb", lambda: fake_lancedb)
+
+    target = tmp_path / "probe_target"
+    ok, reason = probe_atomic_writes(target)
+    assert ok is False
+    assert reason is not None
+    assert "lancedb" in reason.lower() or "lance" in reason.lower()
+    assert "vector_db_dir" in reason
+
+
+def test_probe_uses_integration_oracle_not_mechanism_probe(tmp_path, monkeypatch):
+    """Regression guard against reverting to an os.replace-based probe.
+
+    2026-04-18 smoke test showed that GDrive File Stream permits Python-level
+    os.replace (even rename-over-existing) but still fails LanceDB's Rust-side
+    commit. A mechanism probe based on os.replace produces false negatives and
+    burns Voyage tokens. The probe MUST call into LanceDB to be predictive.
+    If someone 'simplifies' the probe back to a mechanism probe, this test fails.
+    """
+    import video_intel as vi
+
+    lancedb_was_called = {"value": False}
+
+    def tracking_connect(*a, **kw):
+        lancedb_was_called["value"] = True
+
+        class _OK:
+            def create_table(self, *a, **kw):
+                return None
+
+            def drop_table(self, *a, **kw):
+                pass
+
+        return _OK()
+
+    fake_lancedb = SimpleNamespace(connect=tracking_connect)
+    monkeypatch.setattr(vi, "require_lancedb", lambda: fake_lancedb)
+
+    ok, _ = probe_atomic_writes(tmp_path / "probe_target")
+    assert ok is True
+    assert lancedb_was_called["value"] is True, (
+        "probe must call lancedb.connect as the oracle - a mechanism probe "
+        "(os.replace / tempfile / shutil only) produces false negatives on GDFS"
+    )
+
+
+def test_build_search_index_aborts_before_voyage_when_probe_fails(tmp_path, monkeypatch):
+    """Wiring test: probe failure short-circuits before any Voyage client is built."""
+    import video_intel as vi
+
+    bad_path = tmp_path / "bad"
+    config = {"output_dir": str(tmp_path / "out"), "vector_db_dir": str(bad_path)}
+
+    monkeypatch.setattr(vi, "probe_atomic_writes", lambda p: (False, "simulated failure"))
+
+    sentinel = {"voyage_called": False}
+
+    class _ShouldNotBeConstructed:
+        def __init__(self, *a, **kw):
+            sentinel["voyage_called"] = True
+            raise AssertionError("Voyage client built despite probe failure")
+
+    def _fake_require_voyageai():
+        return SimpleNamespace(Client=_ShouldNotBeConstructed)
+
+    def _fake_require_lancedb():
+        return SimpleNamespace(
+            connect=lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("lancedb.connect called despite probe failure")
+            )
+        )
+
+    monkeypatch.setattr(vi, "require_voyageai", _fake_require_voyageai)
+    monkeypatch.setattr(vi, "require_lancedb", _fake_require_lancedb)
+    monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+
+    with pytest.raises(SystemExit):
+        vi.build_search_index(Path(config["output_dir"]), config=config)
+
+    assert sentinel["voyage_called"] is False


### PR DESCRIPTION
## Summary

Introduces `vector_db_dir` config option + a LanceDB integration probe so the vector index can live on local disk when `output_dir` is on a cloud-synced mount. Prevents the ~\$0.30-per-run Voyage embedding waste observed during the 2026-04-18 GDrive File Stream incident.

- **New optional config key** `vector_db_dir` (tilde-expanded, defaults to `output_dir/.lancedb` for backward compatibility).
- **Pre-flight probe** in `build_search_index` that does a throwaway LanceDB connect + 1-row `create_table` + `drop_table`. Aborts before any Voyage call if the round-trip fails.
- **Inline warning block in the shipped `config.yaml`** so future users hit the guard rail at config-edit time, not after paying for a failed embed.
- **ADR-0016** documents the decision plus the two probe iterations that were tried and rejected.

## Why an integration probe (not a mechanism probe)

Two prior iterations based on Python-level `os.replace` (rename-to-new-name, then rename-over-existing) both false-negatived on GDFS during live smoke tests. LanceDB's Rust commit path (`lance-table-4.0.0/src/io/commit.rs:1046`) goes through `object_store::LocalFileSystem`, which hits a different Windows syscall family than Python's. The only reliable oracle is LanceDB itself. Full reasoning + rejected-alternatives in ADR-0016.

## Testing

**Unit** (pytest -m \"not integration\"): 431 pass (7 new).
- Resolver precedence (3 tests)
- Probe success on writable dir
- Probe failure with reason when LanceDB create_table raises
- Regression guard: probe must call `lancedb.connect` (catches anyone reverting to a mechanism probe)
- Wiring: probe failure short-circuits before any `voyageai.Client()` construction

**Sad-path smoke test** against \`G:/My Drive/video-intel/.lancedb\`:
\`\`\`
22:09:47 ERROR   Cannot use vector_db_dir=G:\My Drive\video-intel\.lancedb
22:09:47 ERROR   LanceDB commit failed at probe: lance error: ... Incorrect function. (os error 1).
                 ... Set vector_db_dir in config.yaml to a local path.
\`\`\`
Exit code 1. No \`Embedding X chunks\` log line. **Zero Voyage tokens spent.**

**Happy-path smoke test** against \`C:/Users/danie/video-intel-cache/lancedb\`:
\`\`\`
Indexed 5294 chunks in 1m 51s.
  Index: C:\Users\danie\video-intel-cache\lancedb
\`\`\`
Then \`search --vector \"permission problems\"\` returned 10 ranked hits. Top result: Ray Amjad at [06:12] explaining \`settings.local.json\` permissions + sandbox config - a clean semantic match.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: \`Cannot use vector_db_dir=\` lines emitted by \`cmd_index\`
  - Dashboards: Voyage AI usage graph (embedding spend should NOT spike when indexing against cloud-synced paths)
- **Validation check**
  - \`python scripts/video_intel.py index\` against a cloud-synced path should exit non-zero with the diagnostic, zero Voyage charges on the account
- **Expected healthy behavior**
  - Clean local indexes keep working unchanged (\`vector_db_dir\` unset, default resolves to \`output_dir/.lancedb\`)
  - Users with cloud-synced output_dir uncomment the line in config.yaml and re-run; \`index\` succeeds
- **Failure signal / rollback trigger**
  - Any new \"probe false negative\" report (path passes probe, LanceDB still fails). If this appears, extend the probe (e.g., to also commit a small index) or add an explicit opt-out flag.
- **Validation window & owner**
  - Window: first two \`index\` runs on any new install. Owner: anyone running \`index\` for the first time after this merge.

## Manual cleanup (documented, not automated)

Users who previously ran \`index\` against a cloud-synced \`output_dir\` may have stranded \`.manifest-<uuid>\` files under \`<output_dir>/.lancedb/\`. One-time manual cleanup:

\`\`\`bash
rm -rf \"<output_dir>/.lancedb/\"
\`\`\`

Automating filesystem deletes on a synced cloud path is blast-radius-heavy, so it stays in the user's hands.

## Files

- \`scripts/video_intel.py\`: \`resolve_vector_db_dir\`, \`probe_atomic_writes\` (LanceDB integration probe), wired through \`build_search_index\` / \`hybrid_search\` / \`cmd_index\`.
- \`tests/test_vector_db_config.py\`: 7 new tests.
- \`docs/adr/ADR-0016-vector-db-path-config.md\`: decision + rejected-alternatives + smoke-test findings.
- \`docs/plans/2026-04-18-fix-decouple-lancedb-path-plan.md\`: plan (acceptance boxes all ticked).
- \`CLAUDE.md\`, \`README.md\`, \`config.yaml\`: doc updates + inline warning comment in shipped config.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)