### PR TITLE
docs: natural-language content queries protocol

### DIFF
--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -151,6 +151,32 @@ python "${CLAUDE_SKILL_DIR}/../../scripts/video_intel.py" --model gemini-2.5-pro
 
 Precedence: `--model` flag > `config.yaml` `model` field > `gemini-3-flash-preview`.
 
+## Natural-Language Content Queries
+
+When you ask Claude Code about topics in your video library, the skill routes
+your question through grounded search automatically — you don't need to know
+whether to use vector, hybrid, or concept search internally. Here's what happens:
+
+**Default behavior:** Your question is routed to **hybrid search** (BM25 keyword +
+vector semantic embedding via Voyage AI + rank-reciprocal fusion). This finds
+passages in transcripts that are both keyword-relevant and semantically similar
+to your query, ranked by combined score.
+
+**Output shape:** Results come back as a **narrative summary** with:
+- A thematic headline (the cross-cutting thread)
+- One paragraph per video (what was said and in what context)
+- **Jump links with timestamps** (e.g. `[2:45](https://youtube.com/watch?v=xxx&t=165)`)
+  pointing to the exact moment the evidence was found — no scrubbing, no watching
+  the full video
+
+**Fallback:** If vector search is unavailable (missing `VOYAGE_API_KEY` or index
+not built), the skill falls back to concept search (fast, no API calls). Results
+are video matches only; open the transcript file afterward to read detail.
+
+**See also:** [ADR-0013](../../../docs/adr/ADR-0013-hybrid-search-rrf.md) (hybrid
+search design), [ADR-0016](../../../docs/adr/ADR-0016-vector-db-path-config.md)
+(vector index configuration).
+
 ## How to Use
 
 ### Find videos about a topic (start here)


### PR DESCRIPTION
## Summary

Adds a new **"Natural-language content queries"** section to the video-intel SKILL.md that documents the user-facing behavior of grounded search:

- **Default routing:** Questions are automatically routed to hybrid search (BM25 keyword + vector semantic + RRF fusion)
- **Output shape:** Narrative summaries with thematic headlines, one paragraph per video, and **jump links with timestamps** (`[2:45](https://youtube.com/watch?v=xxx&t=165)`) pointing to the exact moment evidence was found
- **No search-mode knowledge required:** Users ask in natural English; the skill handles vector vs concept fallback transparently
- **Cross-references:** Links to ADR-0013 (hybrid search design) and ADR-0016 (vector DB configuration)

This bridges the ADR-0016 technical work and the user experience: vector search is now documented as "grounded by default with timestamps," setting the expectation that answers come with evidence pinpointing and no wasted video-watching.

## Testing — live run proves the protocol

**Question asked (natural English):** *"what are the best tips, takeaways or knowledge nuggets from @ramjad in the last 30 days"*

**Protocol followed (from the new SKILL.md section):**
1. Routed to `search --vector --channel ramjad` (hybrid BM25+vector+RRF)
2. Post-filtered to 30-day window (2026-03-20 → 2026-04-19)
3. Produced narrative summary with thematic headline + one paragraph per video + `&t=<seconds>` jump links preserved on every citation

**Result:** 8 videos covered in the window, all with jump links. Thematic headline surfaced the arc of the month (the "software factory" vision — autonomous 24/7 multi-agent coding). Ray Amjad's candid critiques of Anthropic features (Ultra Plan, Advisor) came through as the most actionable nuggets — which is exactly the kind of editorial judgment the narrative format enables.

**Coverage observation (follow-up candidate):** Top-10 hybrid ranking doesn't guarantee 30-day recency coverage. Three queries were needed to surface all 8 videos. A future `search --since 30d` flag would let the protocol do one call instead of three — noted for a follow-up issue, not blocking this docs change.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is documentation-only, shipped in the SKILL.md file that every user receives when they clone the plugin. The behavior it documents (hybrid search, timestamps, fallback) is already shipped in PR #8 / ADR-0016.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)