### PR TITLE
config: commit working output_dir + vector_db_dir paths

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # Video Intel configuration
 # Edit this file to add/remove channels and adjust settings.
 
-output_dir: ./video-intel
+output_dir: G:/My Drive/video-intel
 
 # vector_db_dir: where the LanceDB vector index lives. Defaults to output_dir/.lancedb.
 # IMPORTANT: must be on a real local filesystem. Cloud-synced drives (Google Drive File
@@ -9,7 +9,7 @@ output_dir: ./video-intel
 # (os error 1) on Windows. If output_dir is on one of those, uncomment the line below
 # and point it at a local cache directory. The index is derived (rebuildable via the
 # `index` command), so it is safe to live outside output_dir. See ADR-0016.
-# vector_db_dir: ~/.cache/video-intel/lancedb
+vector_db_dir: C:/Users/danie/video-intel-cache/lancedb
 
 default_since: 10d
 default_prompt: mindmap-knowledge


### PR DESCRIPTION
## Summary

Commits the actual runtime config paths that have been proven on this install since 2026-04-18:

- \`output_dir: G:/My Drive/video-intel\` — durable artifacts synced via Google Drive
- \`vector_db_dir: C:/Users/danie/video-intel-cache/lancedb\` — LanceDB MVCC index on local NTFS (GDrive File Stream breaks atomic commits — see ADR-0016)

## Why

Previously the repo shipped with a portable template (\`./video-intel\` + commented \`vector_db_dir\`). Keeping the template meant this developer's working config perpetually showed as a dirty diff on every \`git status\`. Committing the working paths makes the repo reflect reality and stops the nag.

## Downstream impact

**Other users who clone this plugin will need to edit both paths for their own machine.** The warning comment block above \`vector_db_dir\` (already in-file) explains the cloud-sync trap, so the setup story is clear. This is acceptable for a personal/single-maintainer repo; revisit if the plugin goes back to a portable-template stance.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a config-file change scoped to this developer's environment. The indexed LanceDB (5,294 chunks, live at the new path) continues to serve queries without re-indexing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)