### PR TITLE
feat(search): --since flag for date-window queries

### DIFF
--- a/scripts/video_intel.py
+++ b/scripts/video_intel.py
@@ -2457,12 +2457,15 @@ def hybrid_search(
     query: str,
     *,
     channel_filter: str | None = None,
+    since_iso: str | None = None,
     limit: int = 10,
     config: dict[str, Any] | None = None,
 ) -> list[dict]:
     """Search the LanceDB index with hybrid BM25 + vector + RRF fusion.
 
-    Returns ranked chunks deduplicated by video.
+    Returns ranked chunks deduplicated by video. `since_iso` (YYYY-MM-DD) filters
+    chunks whose `published` column is >= the given date, applied pre-rank so
+    recency scope does not get crowded out by older, higher-relevance hits.
     """
     lancedb = require_lancedb()
     voyageai = require_voyageai()
@@ -2495,8 +2498,13 @@ def hybrid_search(
         .text(query)
         .limit(fetch_count)
     )
+    where_clauses = []
     if channel_filter:
-        search_builder = search_builder.where(f"channel = '{channel_filter}'")
+        where_clauses.append(f"channel = '{channel_filter}'")
+    if since_iso:
+        where_clauses.append(f"published >= '{since_iso}'")
+    if where_clauses:
+        search_builder = search_builder.where(" AND ".join(where_clauses))
 
     results = search_builder.to_pandas()
 
@@ -2552,8 +2560,20 @@ def cmd_index(args, config):
         print("  Run 'search --vector \"query\"' to search.")
 
 
-def search_corpus(output_dir: Path, query: str, *, channel_filter: str | None = None, limit: int = 20) -> dict:
-    """Search taxonomy + concepts for matching videos. Returns structured results."""
+def search_corpus(
+    output_dir: Path,
+    query: str,
+    *,
+    channel_filter: str | None = None,
+    since_iso: str | None = None,
+    limit: int = 20,
+) -> dict:
+    """Search taxonomy + concepts for matching videos. Returns structured results.
+
+    `since_iso` (YYYY-MM-DD) post-filters matching videos to those with
+    `published >= since_iso`. Concept data lives in JSON files, so this is
+    a post-rank filter (unlike hybrid_search, which pushes the filter to LanceDB).
+    """
     taxonomy = load_taxonomy(output_dir)
     query_lower = query.lower()
     query_terms = query_lower.split()
@@ -2641,6 +2661,10 @@ def search_corpus(output_dir: Path, query: str, *, channel_filter: str | None = 
                 }
             )
 
+    # Optional date-window filter (applied post-rank; concepts live in JSON, not a query store)
+    if since_iso:
+        matching_videos = [v for v in matching_videos if v.get("published", "") >= since_iso]
+
     # Sort by number of matched concepts (most relevant first), then date
     matching_videos.sort(key=lambda v: (-len(v["matched_concepts"]), v.get("published", "")))
 
@@ -2659,9 +2683,19 @@ def cmd_search(args, config):
     if args.limit is None:
         args.limit = 10 if getattr(args, "vector", False) else 20
 
+    since_raw = getattr(args, "since", None)
+    since_iso = parse_since(since_raw).date().isoformat() if since_raw else None
+
     # Hybrid search mode (BM25 + vector + RRF)
     if getattr(args, "vector", False):
-        hits = hybrid_search(output_dir, args.query, channel_filter=args.channel, limit=args.limit, config=config)
+        hits = hybrid_search(
+            output_dir,
+            args.query,
+            channel_filter=args.channel,
+            since_iso=since_iso,
+            limit=args.limit,
+            config=config,
+        )
         if not hits:
             print(f'No results for "{args.query}". Is the index built? Run: video_intel.py index')
             return
@@ -2703,7 +2737,13 @@ def cmd_search(args, config):
         return
 
     # Concept search mode (default)
-    results = search_corpus(output_dir, args.query, channel_filter=args.channel, limit=args.limit)
+    results = search_corpus(
+        output_dir,
+        args.query,
+        channel_filter=args.channel,
+        since_iso=since_iso,
+        limit=args.limit,
+    )
 
     if not results["concepts"]:
         print(f'No concepts matching "{args.query}".')
@@ -2910,6 +2950,10 @@ Examples:
         default=0.0,
         dest="min_relevance",
         help="Minimum relevance score for hybrid results (default: 0.0, RRF scale)",
+    )
+    search_parser.add_argument(
+        "--since",
+        help="Filter to videos published within a window. Accepts 'Nd' (e.g. '30d') or 'YYYY-MM-DD'.",
     )
 
     # index command

--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -169,6 +169,11 @@ to your query, ranked by combined score.
   pointing to the exact moment the evidence was found — no scrubbing, no watching
   the full video
 
+**Date-window queries:** For "last N days" questions, add `--since 30d` (or any
+`Nd` / `YYYY-MM-DD` value). The filter is pushed into LanceDB *before* ranking,
+so every recent video is considered — recency doesn't get crowded out by older,
+higher-relevance hits. Use this by default for `last N days of [creator]` questions.
+
 **Fallback:** If vector search is unavailable (missing `VOYAGE_API_KEY` or index
 not built), the skill falls back to concept search (fast, no API calls). Results
 are video matches only; open the transcript file afterward to read detail.

--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -9,7 +9,8 @@ description: >
   diagrams, code) captured; add/remove monitored channels; change scan
   settings. Trigger phrases: "what videos cover [topic]", "find videos
   about [concept]", "which creators talk about [subject]", "scan channel",
-  "what's new from [creator]", "watch this for me", "transcribe this
+  "what's new from [creator]", "last N days of [creator]", "recent
+  takeaways from [creator]", "watch this for me", "transcribe this
   video", "transcribe [creator]'s backlog", "videos I'm missing from
   [creator]", "catch up on [creator]", "fully scan [creator]", "backfill
   [creator]", "add [channel] to my watchlist", "what should I watch",
@@ -95,6 +96,7 @@ table is the canonical mapping — read it before picking a command.
 |---|---|---|
 | "find videos about X", "what covers Y" | `search "X"` | Discovery — fast, no API calls |
 | "what did they say about X", "evidence for Y" | `search "X" --vector` | Hybrid search; returns transcript passages |
+| "recent tips / takeaways from [creator]", "last N days of [creator]" | `search "X" --vector --channel Y --since Nd` | Query existing index over a date window; no Gemini calls |
 | "transcribe this video" + URL | `transcript --url URL` | Single video |
 | "scan", "what's new", "check for new videos" | `scan` | All channels, configured `since` |
 | "what's new from [creator]" | `scan --channel X` | Single channel, configured `since` |

--- a/tests/test_search_since.py
+++ b/tests/test_search_since.py
@@ -1,0 +1,216 @@
+"""Tests for the `search --since` flag.
+
+The hybrid search path must accept a `since_iso` kwarg and push it through
+to LanceDB as a pre-rank WHERE clause on the `published` column. Without
+pre-rank filtering, top-10 results don't guarantee coverage of a date window
+(the issue #10 observation: ramjad 2026-03-20..2026-04-19 had 8 videos but
+only 3 surfaced in a single hybrid query).
+
+Concept search also respects `since_iso`: it is a post-rank filter there
+since concepts live in json, not in a query-plan-aware store.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from video_intel import LANCEDB_TABLE
+
+
+class _CapturingBuilder:
+    """Fake LanceDB search builder that records .where() calls."""
+
+    def __init__(self):
+        self.where_clauses: list[str] = []
+
+    def vector(self, _vec):
+        return self
+
+    def text(self, _q):
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def where(self, clause):
+        self.where_clauses.append(clause)
+        return self
+
+    def to_pandas(self):
+        return pd.DataFrame()
+
+
+class _FakeTable:
+    def __init__(self, builder):
+        self._builder = builder
+
+    def search(self, **_kwargs):
+        return self._builder
+
+
+class _FakeDB:
+    def __init__(self, table):
+        self._table = table
+
+    def list_tables(self):
+        return SimpleNamespace(tables=[LANCEDB_TABLE])
+
+    def open_table(self, _name):
+        return self._table
+
+
+@pytest.fixture
+def fake_lancedb(monkeypatch):
+    """Wire up a capturing LanceDB stack and return the builder for assertions."""
+    import video_intel as vi
+
+    builder = _CapturingBuilder()
+    table = _FakeTable(builder)
+    db = _FakeDB(table)
+
+    monkeypatch.setattr(vi, "require_lancedb", lambda: SimpleNamespace(connect=lambda *_a, **_kw: db))
+    monkeypatch.setattr(
+        vi,
+        "require_voyageai",
+        lambda: SimpleNamespace(
+            Client=lambda: SimpleNamespace(embed=lambda *_a, **_kw: SimpleNamespace(embeddings=[[0.0] * 1024]))
+        ),
+    )
+    monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+    return builder
+
+
+def test_hybrid_search_without_since_applies_no_date_filter(fake_lancedb, tmp_path):
+    from video_intel import hybrid_search
+
+    hybrid_search(tmp_path, "tips", config={})
+
+    joined = " ".join(fake_lancedb.where_clauses)
+    assert "published" not in joined, "No --since flag means no published filter should be pushed to LanceDB."
+
+
+def test_hybrid_search_with_since_iso_adds_published_filter(fake_lancedb, tmp_path):
+    from video_intel import hybrid_search
+
+    hybrid_search(tmp_path, "tips", since_iso="2026-03-20", config={})
+
+    joined = " ".join(fake_lancedb.where_clauses)
+    assert "published >= '2026-03-20'" in joined, (
+        f"Expected published filter in WHERE clauses; got: {fake_lancedb.where_clauses}"
+    )
+
+
+def test_hybrid_search_combines_channel_and_since_with_and(fake_lancedb, tmp_path):
+    from video_intel import hybrid_search
+
+    hybrid_search(
+        tmp_path,
+        "tips",
+        channel_filter="ramjad",
+        since_iso="2026-03-20",
+        config={},
+    )
+
+    # Both filters must appear in a single combined clause, AND-joined.
+    # Calling .where() twice in LanceDB replaces, so we combine locally first.
+    assert len(fake_lancedb.where_clauses) == 1, f"Expected one combined WHERE, got {fake_lancedb.where_clauses}"
+    clause = fake_lancedb.where_clauses[0]
+    assert "channel = 'ramjad'" in clause
+    assert "published >= '2026-03-20'" in clause
+    assert " AND " in clause
+
+
+def test_cmd_search_parses_30d_and_passes_iso_to_hybrid(monkeypatch, tmp_path):
+    """--since 30d is parsed once in cmd_search and handed to hybrid_search as YYYY-MM-DD."""
+    import video_intel as vi
+
+    captured: dict[str, str | None] = {"since_iso": "SENTINEL"}
+
+    def fake_hybrid(_output_dir, _query, *, channel_filter=None, since_iso=None, limit=10, config=None):
+        captured["since_iso"] = since_iso
+        return []
+
+    monkeypatch.setattr(vi, "hybrid_search", fake_hybrid)
+    monkeypatch.setattr(vi, "resolve_output_dir", lambda _c: tmp_path)
+
+    args = SimpleNamespace(
+        query="tips",
+        channel=None,
+        limit=None,
+        vector=True,
+        preview=False,
+        min_relevance=0.0,
+        since="30d",
+    )
+
+    vi.cmd_search(args, config={})
+
+    # The resolved ISO should fall within the last 30 days window — validate shape + freshness.
+    expected = (datetime.now(UTC) - timedelta(days=30)).date().isoformat()
+    assert captured["since_iso"] == expected, f"Expected {expected}, got {captured['since_iso']}"
+
+
+def test_cmd_search_absolute_date_passes_through(monkeypatch, tmp_path):
+    """--since 2026-03-20 should be forwarded verbatim as the ISO string."""
+    import video_intel as vi
+
+    captured: dict[str, str | None] = {"since_iso": None}
+
+    def fake_hybrid(_output_dir, _query, *, channel_filter=None, since_iso=None, limit=10, config=None):
+        captured["since_iso"] = since_iso
+        return []
+
+    monkeypatch.setattr(vi, "hybrid_search", fake_hybrid)
+    monkeypatch.setattr(vi, "resolve_output_dir", lambda _c: tmp_path)
+
+    args = SimpleNamespace(
+        query="tips",
+        channel=None,
+        limit=None,
+        vector=True,
+        preview=False,
+        min_relevance=0.0,
+        since="2026-03-20",
+    )
+
+    vi.cmd_search(args, config={})
+    assert captured["since_iso"] == "2026-03-20"
+
+
+def test_search_corpus_since_filter_drops_older_videos(tmp_path):
+    """Concept-mode search post-filters matching videos by published date."""
+    from video_intel import search_corpus
+
+    # Minimal taxonomy + one channel with two videos (one old, one new)
+    (tmp_path / "taxonomy.json").write_text(
+        '{"concepts": {"tips": {"preferred_label": "tips", "aliases": [], "video_count": 2, "domain": ""}}}',
+        encoding="utf-8",
+    )
+    ch = tmp_path / "creator"
+    ch.mkdir()
+
+    def _write_video(prefix: str, published: str, video_id: str):
+        (ch / f"{prefix}.concepts.json").write_text(
+            f'{{"video_id": "{video_id}", "concepts": [{{"concept_id": "tips"}}]}}',
+            encoding="utf-8",
+        )
+        (ch / f"{prefix}.meta.json").write_text(
+            f'{{"title": "{prefix}", "published": "{published}", "video_id": "{video_id}"}}',
+            encoding="utf-8",
+        )
+        (ch / f"{prefix}.transcript.md").write_text("x", encoding="utf-8")
+
+    _write_video("2026-01-01-old", "2026-01-01", "vid_old")
+    _write_video("2026-04-15-new", "2026-04-15", "vid_new")
+
+    # Without filter: both videos returned
+    all_results = search_corpus(tmp_path, "tips")
+    assert {v["video_id"] for v in all_results["videos"]} == {"vid_old", "vid_new"}
+
+    # With since_iso: only the new one
+    filtered = search_corpus(tmp_path, "tips", since_iso="2026-04-01")
+    assert {v["video_id"] for v in filtered["videos"]} == {"vid_new"}


### PR DESCRIPTION
Closes #10.

## Summary

Adds \`search --since\` to both hybrid and concept search modes. Accepts \`Nd\` (e.g. \`30d\`) or absolute \`YYYY-MM-DD\`.

- **Hybrid path:** pushes \`published >= 'YYYY-MM-DD'\` into the LanceDB WHERE clause **pre-rank**, so every video in the window competes for top-10 slots. Combined with \`--channel\` via AND.
- **Concept path:** post-rank filter (concepts live in JSON, not a query-plan-aware store).
- **Parsing:** reuses the existing \`parse_since()\` helper from the \`scan\` command, so UX matches what users already know.

## Live proof (the issue's motivating case)

\`\`\`bash
# Before (yesterday's session): 3 hybrid queries to cover 8 ramjad videos in a 30-day window
# After (today):
python scripts/video_intel.py search \"tips takeaways knowledge nuggets\" \
  --vector --channel ramjad --since 30d --preview
# → 7 of 8 videos surfaced in a single call
# (8th is a same-day second video beyond top-10 limit; raise --limit to include)
\`\`\`

Single-call coverage for natural-English date-bounded questions (the original aspiration from PR #9's SKILL.md protocol) is now the default.

## Testing

New \`tests/test_search_since.py\` with 6 cases:
- no --since → no \`published\` clause in WHERE (don't accidentally filter)
- --since iso → \`published >= 'YYYY-MM-DD'\` pushed to LanceDB
- --channel + --since → single combined AND clause (not two .where() calls, which LanceDB replaces)
- cmd_search parses \`30d\` and passes correctly computed ISO to hybrid_search
- cmd_search passes absolute \`YYYY-MM-DD\` verbatim
- search_corpus (concept mode) post-filters older videos

All 437 existing tests still pass.

## Docs

SKILL.md \"Natural-language content queries\" section gets a new paragraph about date-window questions — so the behavior flows from intent (\"last N days\") to tool invocation without users needing to know the flag name up front.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a CLI-additive change with no behavioral impact on existing queries (no \`--since\` ⇒ no filter applied). The new filter is read-only against the already-indexed \`published\` column.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)