### PR TITLE
docs: testing framework + KB-layer strategy (ADR-0017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,10 @@ All commands support `--force` to regenerate existing output files. Gemini-calli
 
 **Search internals:** Score math, pipeline mechanics, tuning levers, and empirical observations are documented in [`docs/search-internals.md`](docs/search-internals.md). Read this before modifying search behavior.
 
+**Testing and eval framework:** [`docs/testing.md`](docs/testing.md) is the operational reference for both test suites — unit/integration in `tests/` and the grounded-golden-dataset retrieval eval in `tests/evals/`. As of 2026-04-19 the hybrid-search eval baseline is 1/25; any PR that touches retrieval logic must re-run `pytest tests/evals/` and record the new N/25 in the description. The golden dataset at `tests/evals/golden_dataset.yaml` is a frozen contract per [ADR-0017](docs/adr/ADR-0017-kb-layer-strategy.md) — edits need ADR-grade justification.
+
+**KB-layer direction:** [`ADR-0017`](docs/adr/ADR-0017-kb-layer-strategy.md) establishes a staged approach (query expansion → LightRAG → LLM Wiki), each stage gated on eval uplift. Cognee is rejected. The April 2026 brainstorm lives in `work/2026-04-16/04-knowledge-layer-options-brainstorm.md` and `work/2026-04-16/03-architecture-futures-cognee-lightrag-llm-wiki.md` — ADR-0017 is the durable decision record on top of them.
+
 ## Key Design Decisions
 
 - Gemini is a multimodal proxy, not a competing assistant. Video understanding requires vision+audio that Claude doesn't have via API.
@@ -160,11 +164,14 @@ The `output_dir` in `config.yaml` should point outside the plugin folder (e.g. `
 # Install dev dependencies
 pip install -e ".[dev]"
 
-# Run tests
-pytest tests/ -v
+# Run unit/integration tests
+pytest tests/ -v --ignore=tests/evals
 
 # Run tests with coverage
-pytest --cov=scripts --cov-report=term-missing -v
+pytest --cov=scripts --cov-report=term-missing -v --ignore=tests/evals
+
+# Run retrieval eval (requires pip install deepeval, VOYAGE_API_KEY, built LanceDB index)
+pytest tests/evals/ -v -s
 
 # Lint and format
 ruff format .

--- a/compound-engineering.local.md
+++ b/compound-engineering.local.md
@@ -1,0 +1,140 @@
+---
+review_agents:
+  - kieran-python-reviewer
+  - security-sentinel
+  - performance-oracle
+  - architecture-strategist
+  - agent-native-reviewer
+---
+
+# Compound Engineering Config for video-intel
+
+Project context passed to every review agent invoked by `/workflows:review`.
+Read this before assessing any PR.
+
+## What this project is
+
+A Claude Code plugin that uses Google's Gemini multimodal API as a proxy to
+analyze YouTube videos (vision + audio + on-screen text). Claude triages the
+resulting markdown artifacts; it does not call Gemini directly. Two skills
+ship together: `video-intel` (scan / transcript / mindmap / concepts /
+search) and `translate-bcs` (BCS subtitle translation — operationally
+independent from video-intel).
+
+The reasoning substrate is a three-layer pipeline, documented in
+[`ARCHITECTURE.md`](ARCHITECTURE.md):
+
+1. **Source artifacts.** Per-video `meta.json`, `mindmap.md`, `transcript.md`,
+   `concepts.json`. All filesystem-based markdown.
+2. **Concept normalization.** `taxonomy.json` at the output-dir root —
+   canonical concept vocabulary built by the LLM (ADR-0010). Concepts have
+   preferred labels and alias lists.
+3. **Retrieval.** `video_intel search` (concept/taxonomy match) and
+   `video_intel search --vector` (BM25 + vector + RRF fusion on LanceDB
+   via Voyage AI embeddings). See ADR-0012, ADR-0013.
+
+## What reviewers must know
+
+### Retrieval quality is measured, not guessed
+
+As of 2026-04-19, hybrid search scores **1 of 25** on the grounded golden
+dataset at `tests/evals/golden_dataset.yaml`. The staged KB-layer strategy
+driving near-term work is in [ADR-0017](docs/adr/ADR-0017-kb-layer-strategy.md).
+
+**Any PR that touches retrieval logic must re-run `pytest tests/evals/` and
+record the new N/25 in the PR description.** Regressions from 1/25 are
+extremely low-bar and extremely important — the baseline is the floor we're
+building up from, not a ceiling we can afford to drop below.
+
+### Cost-sensitive paths
+
+These operations spend real money. Flag any PR that changes their control
+flow without tests or explicit cost analysis:
+
+- `build_search_index` calls Voyage AI (~$0.02/M tokens × ~5,300 chunks per
+  full re-index).
+- `scan` calls Gemini Flash / Pro per video (~$0.01–$0.05 per 1-hour
+  video depending on model).
+- `transcript` on long videos uses Gemini Pro with `max_output_tokens=65536`.
+  Malformed JSON triggers one bounded retry; a second failure falls through
+  to salvage + partial-write. Do not add unbounded retries.
+
+[ADR-0016](docs/adr/ADR-0016-vector-db-path-config.md) established a hard
+rule: the pre-flight `probe_atomic_writes()` runs *before* any Voyage call.
+A bug there costs ~$0.30 per failed run. Reviewers: verify any rework of
+`build_search_index` preserves that probe-first ordering.
+
+### Timestamps are data, not decoration
+
+Every retrieved chunk has `timestamp_seconds`. The eval harness scores
+`TimestampPrecisionMetric` as a gating metric. Changes to chunking,
+dedup, or rendering that drop or corrupt timestamps break user-visible
+behavior (timestamped links to YouTube `&t=<seconds>`). Reviewers:
+grep for `timestamp_seconds` in any diff touching `hybrid_search`,
+`_dedup_by_video`, or chunk rendering.
+
+A related memory: the user explicitly never wants `&t=<seconds>`
+stripped from YouTube URLs in search-result summaries.
+
+### Provenance tracking matters
+
+The golden dataset has two provenance types — `manual_verified` and
+`concept_augmented_verified` — because not all channels produce transcripts
+(`seankochel`'s `auto_transcript: none` means mindmap-only). Any new
+retrieval / synthesis layer must respect that distinction. Do not assume
+every video has a transcript.
+
+### Filesystem-atomicity gotchas
+
+`output_dir` commonly lives on Google Drive File Stream (confirmed
+working). The `vector_db_dir` separately may *not* — GDFS breaks LanceDB's
+atomic-rename commit path. Any new on-disk store (Stage 2 / Stage 3 from
+ADR-0017) must follow the ADR-0016 pattern: pre-flight integration probe
+using the actual library as the oracle, not a mechanism probe of
+`os.replace`. Mechanism probes empirically produced false negatives and
+burned ~$0.30 of embedding cost per run during the ADR-0016 investigation.
+
+### Skill-parity rule
+
+This is a Claude Code plugin. Any CLI capability should be reachable via
+the skill's natural-language protocol (SKILL.md routing). When a PR adds a
+new subcommand / flag, the corresponding SKILL.md entry is part of the
+diff, not a follow-up. Agent-native-reviewer flags violations.
+
+### Python style
+
+Ruff-formatted, type-hinted, pytest-driven, TDD-preferred. The user's
+stated bias is minimalism — YAGNI per [`specs/agent-rules.md`](specs/agent-rules.md)
+§1 is binding. Don't add config knobs, feature flags, or abstraction layers
+that this PR doesn't require.
+
+### Commit discipline
+
+- Only commit when the user explicitly asks.
+- Never push straight to `main` — always a branch + PR, even for docs-only
+  changes.
+- Prefer follow-up commits over `--amend` once a PR is under peer review.
+- Incremental commits within a PR are fine; WIP commits are not.
+
+## Pointers reviewers will need
+
+- [`CLAUDE.md`](CLAUDE.md) — operational rules, commands, architecture
+  overview. Authoritative when this file disagrees.
+- [`specs/agent-rules.md`](specs/agent-rules.md) — agent constraints;
+  `CLAUDE.md` declares this MUST-read pre-task.
+- [`docs/adr/`](docs/adr/) — decision records. Read the relevant ADR
+  before critiquing a code path.
+- [`docs/testing.md`](docs/testing.md) — testing philosophy, eval harness,
+  current baseline.
+- [`docs/search-internals.md`](docs/search-internals.md) — hybrid search
+  mechanics; the eval measures this pipeline.
+
+## Out of scope for review agents
+
+- **Docs plugins artifacts** — `docs/plans/*.md` and `docs/solutions/*.md`
+  are living / append-only documents; do not flag for deletion or
+  rewriting.
+- **`work/` directory** — ephemeral session notes. Never ask for
+  cleanup, never treat as authoritative.
+- **`plans/` at repo root** — session plan artifacts (historical).
+  Different from `docs/plans/` (durable).

--- a/docs/adr/ADR-0017-kb-layer-strategy.md
+++ b/docs/adr/ADR-0017-kb-layer-strategy.md
@@ -79,14 +79,28 @@ no new data model. Expected effort: 1–2 days. Exit criterion: re-run
 section.
 
 **Stage 2 — LightRAG as the recall-focused graph layer.**
-Only if Stage 1 uplift is insufficient. LightRAG's dual-level graph (local
-entity aggregation + global community detection) directly addresses the
-vocabulary-mismatch failure via alias / co-occurrence propagation, which
-is exactly the mechanism Stage 1's cheap version approximates. Separate
-worktree, dedicated plan via `/workflows:plan`, execution via
-`/workflows:work` with swarm-mode parallel sub-agents for independent
-workstreams (ingestion adapter, graph storage, retrieval integration, eval
-wiring). Exit criterion: same as Stage 1 — record N/25 here.
+LightRAG's dual-level graph (local entity aggregation + global community
+detection) directly addresses the vocabulary-mismatch failure via alias /
+co-occurrence propagation, which is exactly the mechanism Stage 1's cheap
+version approximates. Separate worktree, dedicated plan via
+`/workflows:plan`, execution via `/workflows:work` with swarm-mode
+parallel sub-agents for independent workstreams (ingestion adapter,
+graph storage, retrieval integration, eval wiring). Exit criterion: same
+as Stage 1 — record N/25 here.
+
+### Decision rule between stages
+
+"Stage 1 uplift is insufficient" is defined as: **< 10 of 25 queries
+passing all gating metrics** *and* **the shape of remaining failures is
+still vocabulary-mismatch-dominated** (per-query diagnostic trace on the
+failed queries still shows query-token / content-token divergence as the
+primary signal). If Stage 1 clears 10/25 *and* the remaining failures
+shift to a synthesis-shaped mode (failed queries are `cross_channel_synthesis`
+type with adequate recall but poor composition), skip Stage 2 and go
+straight to Stage 3. The 10/25 threshold is calibrated against the
+original April-16 brainstorm's "≥80% passes = ship wiki" rule, scaled
+down to "a recall intervention earns its week of infrastructure only if
+it closes at least a third of the gap."
 
 **Stage 3 — Karpathy-style LLM Wiki synthesis layer.**
 Addresses the orthogonal synthesis-gap failure mode, not vocabulary
@@ -133,7 +147,11 @@ re-litigating a decision the data already made.
   still lets the eval attribute uplift to the right intervention.
   Attacking both simultaneously with overlapping scopes would blur
   attribution — by explicitly naming "recall" vs "synthesis" as the
-  target of each stage, this ADR prevents that.
+  target of each stage, this ADR prevents that. *Partial overlap is
+  acknowledged*: LightRAG's graph community detection may also surface
+  co-occurrence signal that aids synthesis queries, so if the eval
+  shows synthesis-query uplift during Stage 2 the attribution claim
+  softens — a clean Stage-3 before/after score remains the tiebreaker.
 - **Keeps ADR-0010 / ADR-0013 in force.** The concept / taxonomy layer
   and the hybrid-search RRF fusion are not being replaced. Stages 1–3
   are additions, not migrations.
@@ -143,7 +161,19 @@ re-litigating a decision the data already made.
 - **The eval dataset becomes a frozen contract.** Adding or changing
   golden queries mid-stream invalidates stage-over-stage comparison.
   Dataset changes now need ADR-grade justification, documented at the
-  same level as a metric-threshold change.
+  same level as a metric-threshold change. **Corrections are exempt:**
+  fixing a typo in a query string, correcting a wrong `video_id`
+  (grounding error), or adjusting a `key_phrase` to match actual
+  transcript text are corrections — they remove measurement noise, not
+  recalibrate difficulty — and do not require a new ADR. What needs an
+  ADR is adding / removing queries, shifting a `query_type`, or changing
+  a per-query threshold.
+- **The dataset reflects a single author's framing.** The 25 queries
+  were written by the same person now designing the KB-layer
+  interventions. There is a latent risk that Stage 1–3 work subtly fits
+  this dataset rather than generalizing to external users. Mitigations
+  tracked in Related Debt: rotate in adversarial queries at stage
+  boundaries, and solicit external raters once a KB layer is live.
 - **Deterministic metrics don't measure synthesis quality.** The current
   four metrics (`RecallAtKMetric`, `MRRMetric`, `ChannelCoverageMetric`,
   `TimestampPrecisionMetric`) are all recall / precision metrics. The

--- a/docs/adr/ADR-0017-kb-layer-strategy.md
+++ b/docs/adr/ADR-0017-kb-layer-strategy.md
@@ -1,0 +1,289 @@
+# Staged KB-Layer Strategy, Gated by the 25-Query Eval
+
+**Status:** accepted
+
+**Date:** 2026-04-19
+
+**Decision Maker(s):** Daniel Zivkovic
+
+## Context
+
+[ADR-0012](ADR-0012-vector-search-lancedb-voyage.md) and
+[ADR-0013](ADR-0013-hybrid-search-rrf-fusion.md) shipped two generations of the
+retrieval layer: vector-only (~62% precision) then BM25 + vector + RRF fusion
+(~84% precision on a small ad-hoc sample). Both were evaluated on hand-picked
+queries, not a frozen benchmark. By 2026-04-16 three candidate "Layer 3" KB
+options were on the table — Cognee, LightRAG, and a Karpathy-style LLM Wiki —
+with no objective way to choose between them. The
+[knowledge-layer brainstorm](../../work/2026-04-16/04-knowledge-layer-options-brainstorm.md)
+and the [architecture-futures note](../../work/2026-04-16/03-architecture-futures-cognee-lightrag-llm-wiki.md)
+concluded with an explicit forcing function: *"Let the benchmark decide, not
+upfront design."* The brainstorm proposed a threshold of ≥80% on a future eval
+as the gate for shipping a wiki layer, with <70% triggering a revisit of
+Cognee or LightRAG.
+
+On 2026-04-19 that benchmark was built and run. The artifacts are
+[`tests/evals/golden_dataset.yaml`](../../tests/evals/golden_dataset.yaml)
+(25 grounded queries, 90 timestamped expected hits across 7 active channels)
+and [`tests/evals/metrics.py`](../../tests/evals/metrics.py) (four deterministic
+DeepEval `BaseMetric` subclasses: `RecallAtKMetric`, `MRRMetric`,
+`ChannelCoverageMetric`, `TimestampPrecisionMetric`). The full harness is at
+[`tests/evals/test_search_quality.py`](../../tests/evals/test_search_quality.py).
+
+The baseline result on hybrid search (`video_intel search --vector`):
+
+```text
+1 of 25 queries passed all gating metrics (Q15 only).
+Single-channel baselines:   ~11% average recall (target was 75%)
+Cross-channel comparative:  ~25% average recall (target was 50–70%)
+Cross-channel synthesis:     ~5% average recall (target was 30–50%)
+```
+
+That is ~4% overall. The <70% threshold from the April 16 brainstorm is not
+just crossed — it's inverted: hybrid search is currently ~18× below the
+revisit-graph trigger.
+
+Diagnostic reading of the per-query trace:
+
+- **Primary failure mode is vocabulary mismatch.** Golden queries phrase
+  user-intent vocabulary ("reliable agents", "context engineering"). Content
+  uses creator vocabulary ("Ralph Wiggum / force-feed", "Factorio parallel
+  sessions", "Capybara"). BM25 + vector RRF fusion does not bridge the gap at
+  top-K.
+- **The one passing query (Q15) is the exception that proves the rule.**
+  Q15's query phrase is "Opus 4.7, Gemma 4, Sonnet 4.6" — exact model-name
+  overlap with transcript text. BM25 dominates, hybrid wins.
+- **Data health is not the issue.** Spot-checked gold `video_id`s are all
+  present in the 5,294-chunk index. This is a retrieval failure, not an
+  ingestion failure.
+
+The question is no longer *"which KB layer?"* but *"what's the cheapest
+intervention that moves the 4% number, and how do we stay honest about which
+intervention earned which point?"*
+
+## Decision
+
+**Stage KB-layer interventions from cheapest to heaviest, gating each stage
+on an eval re-run against the same 25 queries.** Do not parallel-bake
+options that address different failure modes as if they were competing.
+
+### The stages
+
+**Stage 1 — Query expansion via existing taxonomy aliases.**
+Pre-process user queries through `taxonomy.json` and `concepts.json` before
+BM25 / vector lookup. When a query token matches a concept alias, expand
+the query to include the concept's canonical label and sibling aliases.
+Uses existing artifacts only — no new infrastructure, no new dependencies,
+no new data model. Expected effort: 1–2 days. Exit criterion: re-run
+`pytest tests/evals/` and record the new N/25 in this ADR's Consequences
+section.
+
+**Stage 2 — LightRAG as the recall-focused graph layer.**
+Only if Stage 1 uplift is insufficient. LightRAG's dual-level graph (local
+entity aggregation + global community detection) directly addresses the
+vocabulary-mismatch failure via alias / co-occurrence propagation, which
+is exactly the mechanism Stage 1's cheap version approximates. Separate
+worktree, dedicated plan via `/workflows:plan`, execution via
+`/workflows:work` with swarm-mode parallel sub-agents for independent
+workstreams (ingestion adapter, graph storage, retrieval integration, eval
+wiring). Exit criterion: same as Stage 1 — record N/25 here.
+
+**Stage 3 — Karpathy-style LLM Wiki synthesis layer.**
+Addresses the orthogonal synthesis-gap failure mode, not vocabulary
+mismatch. The ~5% baseline on synthesis queries indicates hybrid retrieval
+cannot compose answers from multiple sources even when recall succeeds.
+Wiki pages pre-compute those compositions. Can run *parallel* to Stage 2
+in a separate worktree — they target different failure modes, so
+concurrent execution is not a bake-off, it's two independent interventions
+scored against the same 25 queries. Exit criterion: same as above.
+
+### What the eval gates, and what it does not
+
+The eval gates *which KB-layer intervention to prioritize next*. It does
+not gate whether KB-layer work is worth doing at all — that was already
+settled by the 1/25 baseline. A score of 4% on a benchmark the user's own
+prior rule set to ≥70% for "stay put" is sufficient justification to
+proceed.
+
+### Cognee is rejected, not staged
+
+The [2026-04-16 brainstorm](../../work/2026-04-16/04-knowledge-layer-options-brainstorm.md)
+established that Cognee duplicates the `concepts.json` extraction work
+already shipped in [ADR-0010](ADR-0010-llm-concept-normalization.md), is
+designed for multi-tenant enterprise (overkill for single-user research),
+and was at v1.0.1.dev1 on release day (production risk for consulting
+work). LightRAG has the same re-extraction cost but adds community
+detection that Cognee lacks. Putting Cognee in a staged plan means
+re-litigating a decision the data already made.
+
+## Consequences
+
+### Positive Consequences
+
+- **No more vibes competition.** Every KB-layer experiment re-runs the
+  same 25 queries. ROI is the N/25 uplift delta. Cheap-first guarantees
+  the project never invests in a heavy layer before testing whether a
+  light one sufficed.
+- **Early-stop permission.** If Stage 1 lifts 1/25 → 8/25 or better, the
+  remaining 17 failures become diagnostically cleaner (not vocabulary).
+  That sharpens what Stage 2 needs to address, and may raise the bar for
+  Stage 2 to justify itself.
+- **Attribution is preserved.** Because Stage 2 (LightRAG) and Stage 3
+  (Wiki) address orthogonal failure modes, running them concurrently
+  still lets the eval attribute uplift to the right intervention.
+  Attacking both simultaneously with overlapping scopes would blur
+  attribution — by explicitly naming "recall" vs "synthesis" as the
+  target of each stage, this ADR prevents that.
+- **Keeps ADR-0010 / ADR-0013 in force.** The concept / taxonomy layer
+  and the hybrid-search RRF fusion are not being replaced. Stages 1–3
+  are additions, not migrations.
+
+### Negative Consequences
+
+- **The eval dataset becomes a frozen contract.** Adding or changing
+  golden queries mid-stream invalidates stage-over-stage comparison.
+  Dataset changes now need ADR-grade justification, documented at the
+  same level as a metric-threshold change.
+- **Deterministic metrics don't measure synthesis quality.** The current
+  four metrics (`RecallAtKMetric`, `MRRMetric`, `ChannelCoverageMetric`,
+  `TimestampPrecisionMetric`) are all recall / precision metrics. The
+  golden dataset declares `position_diversity` and `essay_coverage`
+  dimensions that require G-Eval (LLM-judge) metrics still to be
+  implemented. Stage 3 (Wiki) in particular will need those metrics to
+  be measurable — expect a follow-up work item to wire G-Eval before
+  Stage 3 exits.
+- **Staged execution is calendar-slower than a parallel bake-off.**
+  Stage 1 has to finish before Stage 2 decision. In exchange we avoid
+  building heavy infrastructure that the cheap fix might have
+  rendered unnecessary. The trade is discipline over speed.
+- **Some eval coverage assumptions are untested.** Timestamp-precision
+  thresholds were calibrated against transcript-sourced gold entries;
+  `seankochel` channel entries use mindmap-sourced timestamps
+  (bullet-level, not chunk-level), and may be systematically
+  pessimistic. Treat any Seankochel-only uplift signal as suspect
+  until a separate audit confirms thresholds are fair.
+
+### Baseline and future measurements
+
+| Date | Intervention | Score | Notes |
+| ---- | ------------ | ----- | ----- |
+| 2026-04-19 | Hybrid search (ADR-0012 + ADR-0013) | 1 / 25 | Q15 only. Vocabulary mismatch is primary failure. |
+| *Stage 1 TBD* | Query expansion via taxonomy aliases | — | Record here after `/workflows:work` completes. |
+| *Stage 2 TBD* | LightRAG layer | — | Only if Stage 1 insufficient. |
+| *Stage 3 TBD* | LLM Wiki synthesis | — | Parallel-safe with Stage 2. |
+
+## Alternatives Considered
+
+- **Parallel bake-off of LightRAG vs Wiki.** Run both in separate
+  worktrees from the start, pick the winner.
+  - **Pros:** Fastest calendar time. Maximizes MAX-plan parallel
+    compute.
+  - **Cons:** They solve different failure modes. "Winner" is a
+    category error — the eval score could lift for either, for
+    different reasons. Also skips Stage 1, which is the cheapest
+    falsifier of the vocabulary-mismatch hypothesis.
+  - **Status:** rejected. Parallel execution is retained as an
+    option at Stages 2 & 3, but only after Stage 1 results.
+
+- **Pick LightRAG outright, skip Stage 1.** Commit to the heavy
+  intervention the April 16 brainstorm conditionally recommended for
+  sub-70% eval scores.
+  - **Pros:** Most direct attack on the measured failure (vocabulary
+    mismatch via graph).
+  - **Cons:** Violates the "let the benchmark decide" rule in a
+    subtle way — it skips testing whether a cheap solution would
+    have been enough. One to two days of Stage 1 work is a small
+    price for the signal of whether a one-week LightRAG integration
+    is justified.
+  - **Status:** rejected.
+
+- **Pick Wiki outright, as the April 16 brainstorm recommended.**
+  Ship synthesis pages on top of current hybrid search without
+  addressing recall failure first.
+  - **Pros:** Aligns with the project's stated consulting-ready goal
+    ("here's what creators say about X" > "here are 47 search
+    results").
+  - **Cons:** Wiki pages synthesize from retrieved sources. If
+    retrieval misses 96% of relevant material (the 1/25 baseline),
+    the synthesis layer is compounding from a broken foundation. Fix
+    recall first, synthesize second.
+  - **Status:** deferred to Stage 3.
+
+- **Do nothing, accept the 1/25 baseline.** Declare hybrid search
+  sufficient and ship the project as-is.
+  - **Pros:** Zero effort.
+  - **Cons:** Fails the stated project goal (surfacing non-obvious
+    cross-channel insights), and fails the user's own explicit
+    threshold from April 16 (<70% triggers a revisit).
+  - **Status:** rejected.
+
+- **Rewrite the eval dataset to be less demanding.** Lower thresholds
+  until the current system passes.
+  - **Pros:** Instantly improves the score.
+  - **Cons:** Adversarial to the purpose of having an eval. Treated
+    as a failure mode of the decision process to guard against, not
+    an option.
+  - **Status:** rejected with prejudice. Future dataset edits require
+    an ADR.
+
+## Affects
+
+Source files and artifacts that this decision governs going forward:
+
+- `tests/evals/golden_dataset.yaml` — frozen contract; edits require
+  ADR-level justification per Consequences above.
+- `tests/evals/metrics.py` — adding G-Eval metrics for synthesis
+  dimensions is Stage 3 prerequisite work.
+- `tests/evals/test_search_quality.py` — harness; may add a CSV-writing
+  hook to record stage-over-stage scores automatically.
+- `scripts/video_intel.py` — Stage 1 adds a query-expansion preprocessor
+  (exact location TBD in the Stage 1 plan).
+- `docs/plans/2026-04-19-feat-kb-stage1-query-expansion-plan.md` (TBD) —
+  Stage 1 tactical plan, produced via `/workflows:plan`.
+
+## Related Debt
+
+Follow-ups spawned by this decision, to track in GitHub Issues per
+`CLAUDE.md` backlog convention:
+
+- **G-Eval metrics for `position_diversity` and `essay_coverage`.**
+  Declared in the golden dataset, not yet implemented in
+  `tests/evals/metrics.py`. Prerequisite for Stage 3 scoring.
+- **Timestamp-precision audit for `seankochel` mindmap-sourced gold
+  entries.** Thresholds may be systematically too strict; could be
+  masking real recall.
+- **CSV / structured log of stage-over-stage eval scores.** Currently
+  scores are captured in memory and in this ADR's Consequences
+  table. A machine-readable log would make regression detection
+  automatic.
+- **`docs/solutions/rejected-paths/` directory.** Flagged as missing
+  in the
+  [2026-04-16 brainstorm](../../work/2026-04-16/04-knowledge-layer-options-brainstorm.md).
+  Create it when the first post-mortem needs it (e.g., if a staged
+  experiment itself fails and we want the lesson on record).
+
+## Research References
+
+- [Plan: 2026-04-19-testing-and-kb-layer-strategy (session artifact)](../../plans/humming-jumping-lollipop.md)
+- [ADR-0010: LLM Concept Normalization](ADR-0010-llm-concept-normalization.md) — the concept / thesaurus substrate Stage 1 reuses.
+- [ADR-0012: Vector Search via LanceDB + Voyage AI](ADR-0012-vector-search-lancedb-voyage.md) — the index the eval runs against.
+- [ADR-0013: Hybrid Search RRF Fusion](ADR-0013-hybrid-search-rrf-fusion.md) — the retrieval path the 1/25 baseline measures.
+- [Knowledge-layer options brainstorm](../../work/2026-04-16/04-knowledge-layer-options-brainstorm.md) — the "let the benchmark decide" rule originates here.
+- [Architecture futures: Cognee vs LightRAG vs LLM Wiki](../../work/2026-04-16/03-architecture-futures-cognee-lightrag-llm-wiki.md) — comparative option analysis.
+- [DeepEval docs — custom non-LLM metrics](https://deepeval.com/docs/metrics-custom) — `BaseMetric` contract used by `tests/evals/metrics.py`.
+- [LightRAG paper (EMNLP 2025)](https://arxiv.org/abs/2410.05779) — dual-level graph retrieval, cited in Stage 2 rationale.
+- [Karpathy's LLM Wiki gist](https://gist.github.com/karpathy) — pattern cited in Stage 3 rationale.
+
+## Notes
+
+This ADR does *not* supersede ADR-0010, 0012, or 0013. The concept layer,
+vector index, and hybrid retrieval fusion all remain in force. Stage 1
+extends the retrieval preprocessor; Stages 2 and 3 add new retrieval /
+synthesis layers alongside hybrid. The existing layers keep being
+scored against the same eval at every stage so regressions are visible.
+
+The April 16 brainstorm's recommendation (Future D + eval gate) is not
+discarded. It is being executed literally: the eval is the gate. The
+gate said *recall is broken more than synthesis*, so the ordering
+changes, and Future D becomes Stage 3 instead of Stage 1. The
+philosophical direction — synthesis over pure retrieval — is preserved.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,11 @@ Files are named: `ADR-NNNN-title-with-dashes.md`
 | [ADR-0010](ADR-0010-llm-concept-normalization.md) | LLM-powered concept normalization (thesaurus layer) | accepted | 2026-04-01 |
 | [ADR-0011](ADR-0011-structured-logging.md) | Structured logging via Python logging module | accepted | 2026-04-02 |
 | [ADR-0012](ADR-0012-vector-search-lancedb-voyage.md) | Vector search via LanceDB + Voyage AI embeddings | accepted | 2026-04-02 |
+| [ADR-0013](ADR-0013-hybrid-search-rrf-fusion.md) | Hybrid search via BM25 + vector + Reciprocal Rank Fusion | accepted | 2026-04-03 |
+| [ADR-0014](ADR-0014-standalone-bcs-translation-workflow.md) | Standalone BCS translation workflow for audio-first long-form video | accepted | 2026-04-11 |
+| [ADR-0015](ADR-0015-permissive-safety-filters-for-faithful-reporting.md) | Permissive safety filters for faithful reporting pipelines | accepted | 2026-04-11 |
+| [ADR-0016](ADR-0016-vector-db-path-config.md) | Decouple LanceDB vector index path from output_dir | accepted | 2026-04-18 |
+| [ADR-0017](ADR-0017-kb-layer-strategy.md) | Staged KB-layer strategy, gated by the 25-query eval | accepted | 2026-04-19 |
 
 ## Process
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,6 +63,8 @@ Files are named: `ADR-NNNN-title-with-dashes.md`
 - **`CLAUDE.md`**: Operational context for Claude Code (commands, packaging, release)
 - **`ARCHITECTURE.md`**: System overview and vision (WHERE it's heading)
 - **`docs/adr/`**: Decisions (WHY we chose this approach)
+- **[`docs/testing.md`](../testing.md)**: Testing discipline and the retrieval-eval harness (HOW we measure that we're still on track)
+- **[`docs/search-internals.md`](../search-internals.md)**: Hybrid-search mechanics — the pipeline the eval measures
 
 ## Working with AI Assistants
 

--- a/docs/brainstorms/2026-04-19-kb-layer-staged-experiments-brainstorm.md
+++ b/docs/brainstorms/2026-04-19-kb-layer-staged-experiments-brainstorm.md
@@ -1,0 +1,162 @@
+# KB Layer — Staged Experiments Brainstorm
+
+**Date:** 2026-04-19
+
+**Status:** consolidated into [ADR-0017](../adr/ADR-0017-kb-layer-strategy.md)
+
+## Supersedes
+
+This document promotes the durable reasoning from the two 2026-04-16 scratch
+notes into canonical `docs/brainstorms/`. The scratch notes remain for
+historical record but are no longer the authoritative reference:
+
+- [work/2026-04-16/03-architecture-futures-cognee-lightrag-llm-wiki.md](../../work/2026-04-16/03-architecture-futures-cognee-lightrag-llm-wiki.md)
+- [work/2026-04-16/04-knowledge-layer-options-brainstorm.md](../../work/2026-04-16/04-knowledge-layer-options-brainstorm.md)
+
+If you read one file first, read this one. If you want the decision (not
+the exploration), read [ADR-0017](../adr/ADR-0017-kb-layer-strategy.md).
+If you want the narrative archaeology, read the two scratch notes above.
+
+## What prompted this
+
+On 2026-04-16 three KB-layer candidates were on the table and the
+brainstorm concluded with an explicit rule: *"Let the benchmark decide,
+not upfront design."* The brainstorm set 80% as the threshold for
+"ship a wiki layer on top of current hybrid search," and <70% as the
+trigger to revisit graph options (Cognee / LightRAG).
+
+On 2026-04-19 the benchmark was built
+([`tests/evals/golden_dataset.yaml`](../../tests/evals/golden_dataset.yaml))
+and run. Result: **1 of 25** (~4%). That's well past the <70% trigger —
+graph options are back on the table, but only to the extent the eval
+confirms they earn their uplift.
+
+## The four options, briefly
+
+### Option A — Stay put, finish the existing roadmap
+
+Keep hybrid BM25 + vector as the only retrieval. Tune prompts. Add a
+`brief` subcommand that runs a query and produces a Claude-invokable
+synthesis inline.
+
+- **Effort:** Days.
+- **Fits "consulting-ready" goal:** 7/10.
+- **Why it's not sufficient:** The 1/25 baseline shows retrieval itself
+  is the bottleneck. Adding a synthesis layer on broken retrieval
+  compounds errors, not value.
+
+### Option B — Cognee as Layer 3
+
+Feed mindmaps, transcripts, concepts.json into Cognee. Graph relations,
+remember / recall / forget / improve API. Uses LanceDB internally.
+
+- **Effort:** 1–2 weeks + maintenance.
+- **Fits goal:** 6/10.
+- **Why rejected:** Forces its own extraction pipeline (duplicates
+  [ADR-0010](../adr/ADR-0010-llm-concept-normalization.md)'s
+  `concepts.json` work). Designed for multi-tenant enterprise. v1.0
+  just shipped on release day — production risk for consulting work.
+
+### Option C — LightRAG as Layer 3
+
+Dual-level graph: local entity aggregation + global community
+detection. EMNLP 2025 paper. Largest adoption momentum.
+
+- **Effort:** ~1 week + maintenance.
+- **Fits goal:** 8/10 (global mode answers the "what do creators X, Y,
+  Z agree on?" question natively).
+- **Caveat:** Re-runs its own entity extraction on top of ours. Two
+  parallel vocabularies. Graph alias propagation is the mechanism
+  that directly addresses the measured failure (vocabulary mismatch).
+
+### Option D — LLM Wiki on existing artifacts
+
+The project has ~70% of a Karpathy-style LLM Wiki already: raw sources
+(videos + meta.json), LLM pages (mindmaps + transcripts), canonical
+vocabulary (taxonomy.json), hybrid query layer
+([ADR-0013](../adr/ADR-0013-hybrid-search-rrf-fusion.md)). Missing:
+cross-references, synthesis pages, index.md/log.md.
+
+- **Effort:** ~1 week for v1.
+- **Fits goal:** 9/10. Zero new vendors. Obsidian-compatible output.
+- **Limitation:** Pre-computed synthesis solves the *synthesis* failure
+  mode (5% baseline on synthesis queries), not the *recall* failure
+  mode (primary bottleneck in the 1/25 result).
+
+## The shift between 2026-04-16 and 2026-04-19
+
+On 2026-04-16 the recommendation was **D + eval + A as scaffolding**,
+with B/C deferred. That recommendation was eval-blind — it was the best
+guess given no measurement.
+
+On 2026-04-19 the eval tells us *which* failure mode dominates:
+**vocabulary mismatch** (primary, affects ~90% of queries) far outweighs
+**synthesis gap** (secondary, affects ~20% of queries — and even those
+are also bottlenecked on recall since you can't synthesize what you
+can't retrieve).
+
+The recommendation therefore sharpens into a **staged order**, not a
+different choice:
+
+- **Stage 1:** Cheapest test of the vocabulary-mismatch hypothesis —
+  query expansion via existing `taxonomy.json` aliases. 1–2 days.
+- **Stage 2:** LightRAG (Option C). The graph alias propagation is the
+  heavy version of what Stage 1 approximates cheaply. Only if Stage 1
+  uplift is insufficient.
+- **Stage 3:** Wiki (Option D). Synthesis is orthogonal to recall —
+  this addresses the 5% baseline on synthesis queries. Parallel-safe
+  with Stage 2.
+- **Rejected:** Option B (Cognee) — duplicates existing work, overkill
+  for single-user, pre-1.0 risk.
+
+## Four-futures table, re-annotated with 2026-04-19 eval data
+
+| Option | Pre-eval fit | Post-eval role | Stage |
+|--------|--------------|---------------|-------|
+| A — Stay put | 7/10 (scaffolding) | Insufficient alone (1/25) | Baseline (gate) |
+| B — Cognee | 6/10 | Duplicates ADR-0010; no unique value | Rejected |
+| C — LightRAG | 8/10 | Directly addresses primary failure (vocabulary) | Stage 2 |
+| D — LLM Wiki | 9/10 (synthesis) | Addresses secondary failure (synthesis gap) | Stage 3 |
+| —  | — | Cheap upper-bound test before Stage 2 | Stage 1 (query expansion, new) |
+
+## Key decisions captured here (for searchability)
+
+- **The eval is the gate.** Every stage re-runs `pytest tests/evals/`.
+  ROI is the N/25 uplift delta. Dataset changes require ADR-grade
+  justification.
+- **Cheapest-first.** Before investing in a graph DB (Stage 2), try
+  query expansion via existing `taxonomy.json` (Stage 1). If the cheap
+  fix hits ≥10/25 or so, the graph layer may not be needed.
+- **Orthogonal failure modes can run parallel.** Stage 2 (recall) and
+  Stage 3 (synthesis) target different metrics and can be built
+  concurrently in separate worktrees without blurring attribution.
+- **No parallel bake-off of Cognee vs LightRAG.** Cognee is rejected;
+  there's no competition to run.
+- **The eval dataset is a frozen contract.** Per
+  [ADR-0017](../adr/ADR-0017-kb-layer-strategy.md), edits to
+  `tests/evals/golden_dataset.yaml` need an ADR update.
+
+## Open questions still relevant
+
+- **When is Stage 1 "enough" to skip Stage 2?** The brainstorm's
+  original threshold was ≥80% = ship wiki / <70% = revisit graph.
+  Stage 1 likely won't hit 80% — it's a cheap fix, not a
+  silver-bullet. A more useful heuristic after Stage 1:
+  - If the *remaining* failures are recall-shaped (wrong/missing
+    videos) → proceed to Stage 2.
+  - If they're synthesis-shaped (right videos, can't compose) →
+    skip to Stage 3.
+- **G-Eval metrics for synthesis.** `position_diversity` and
+  `essay_coverage` dimensions are defined in the golden dataset but
+  not implemented in `tests/evals/metrics.py`. Stage 3 cannot be
+  fairly scored without them.
+- **Timestamp precision for mindmap-sourced gold entries
+  (`seankochel`).** May be systematically too strict since mindmap
+  timestamps are bullet-level, not chunk-level. Could mask real
+  recall if Stage 2 produces mindmap-level hits.
+
+## What to read next
+
+- [ADR-0017 — Staged KB-Layer Strategy](../adr/ADR-0017-kb-layer-strategy.md) — the canonical decision record.
+- [docs/testing.md](../testing.md) — how to run the eval; how to interpret the 1/25 baseline.
+- `docs/plans/2026-04-19-feat-kb-stage1-query-expansion-plan.md` *(not yet written)* — Stage 1 tactical plan, produced via `/workflows:plan` after this brainstorm ratifies.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,191 @@
+# Testing
+
+Operational reference for how this project is tested. For *why* DeepEval
+was chosen and *why* the retrieval baseline is 1/25, see
+[ADR-0017](adr/ADR-0017-kb-layer-strategy.md).
+
+Last verified: 2026-04-19
+
+## Two Test Suites, Two Different Guarantees
+
+| Suite | Directory | What it guarantees | How to run |
+|-------|-----------|--------------------|------------|
+| Unit / integration | [`tests/`](../tests/) | Code correctness — parsing, idempotency, error handling, CLI flags. Runs in seconds. | `pytest tests/ -v` (excluding `tests/evals/`) |
+| Retrieval eval | [`tests/evals/`](../tests/evals/) | Retrieval **quality** against 25 frozen grounded queries. Runs Voyage API, ~1 min and a few cents. | `pytest tests/evals/ -v -s` |
+| Search CLI smoke grid | [`evals/search-eval-queries.md`](../evals/search-eval-queries.md) | Human-run sanity grid for CLI features (`--preview`, `--min-similarity`, `--limit`, dedup). Prose benchmark, not pytest. | Read the file, run queries manually, score 0/1/2. |
+
+The first two are machine-graded. The third is narrative — an eyeball-test
+grid kept alongside the code for when adding CLI features, not for
+measuring retrieval quality.
+
+## Retrieval Eval — Why DeepEval
+
+Four criteria eliminated most of the field:
+
+- **Pytest-native** — evals should be a `pytest` run, not a separate CLI or
+  service. DeepEval metrics subclass `BaseMetric` and slot into
+  `assert_test()` or bare parametrized tests.
+- **Small-team overhead** — one-person maintenance. No cloud platform,
+  no separate dashboard server, no account.
+- **Deterministic-metric support** — the project needs recall / precision
+  metrics (`video_id` overlap, channel coverage, timestamp windows), not
+  just LLM-judge scoring. DeepEval natively supports non-LLM `BaseMetric`
+  subclasses with `measure` / `a_measure` / `is_successful`.
+- **LLM-judge escape hatch for later** — DeepEval also ships `GEval` for
+  when synthesis-quality dimensions need grading (e.g., the
+  `position_diversity` / `essay_coverage` dimensions declared in the
+  golden dataset but not yet implemented — see
+  [ADR-0017](adr/ADR-0017-kb-layer-strategy.md) Related Debt).
+
+Alternatives surveyed (RAGAS, PromptFoo, TruLens, Inspect AI, Vectara
+Eval) were either tied to a specific framework, cloud-platform-centric,
+or thinner on deterministic-custom-metric support. DeepEval hit all four
+criteria.
+
+## The 25-Query Golden Dataset
+
+Location: [`tests/evals/golden_dataset.yaml`](../tests/evals/golden_dataset.yaml).
+Structure: one top-level `queries:` list. Each entry has:
+
+| Field | Meaning |
+|-------|---------|
+| `id` | `Q01` … `Q25`. Stable identifier used in test IDs. |
+| `query` | The user-intent phrasing sent to `hybrid_search`. |
+| `query_type` | `single_channel_baseline`, `cross_channel_comparative`, or `cross_channel_synthesis`. Sets expected difficulty. |
+| `concept_ids` | Taxonomy concept IDs the query targets (aids Stage-1 query-expansion work). |
+| `known_good_answer` | Prose summary of what a perfect answer would include. Used by future LLM-judge metrics. |
+| `expected_hits` | List of grounded hits: `video_id`, `channel`, `timestamp_range`, `key_phrase`, `position`, `provenance` (`manual_verified` vs `concept_augmented_verified`). |
+| `dimensions` | Per-metric thresholds — e.g., `recall_at_k: {k: 10, threshold: 0.6}`. |
+
+Every `expected_hit` is grounded in the actual corpus: the `video_id` must
+exist in the LanceDB index, and the `timestamp_range` must correspond to
+text that contains the `key_phrase`. There are no synthetic entries.
+
+Provenance matters:
+
+- `manual_verified` — human confirmed the passage is the right answer.
+- `concept_augmented_verified` — the hit came from the concept / taxonomy
+  layer and was confirmed to match the expected content; useful for
+  `seankochel` entries where transcripts don't exist (mindmap-sourced).
+
+**Timestamp precision caveat:** `seankochel` entries use bullet-level
+timestamps from mindmaps, not chunk-level timestamps from transcripts.
+The `timestamp_precision` thresholds are looser for those queries but may
+still be systematically too strict. Tracked in
+[ADR-0017](adr/ADR-0017-kb-layer-strategy.md) Related Debt.
+
+**The dataset is a frozen contract.** Per ADR-0017, adding or changing
+queries mid-experiment invalidates stage-over-stage comparison. Edits
+require ADR-grade justification.
+
+## Running the Eval
+
+### Prerequisites
+
+- `pip install deepeval` — not in core `pyproject.toml`; treat as optional
+  dev dependency for now (candidate for a future `[eval]` extras group).
+- `VOYAGE_API_KEY` — the harness embeds queries before searching.
+- `GEMINI_API_KEY` — not used by current deterministic metrics, but
+  reserved for future G-Eval metrics.
+- LanceDB index must exist at the resolved `vector_db_dir` (see
+  [ADR-0016](adr/ADR-0016-vector-db-path-config.md)). Build it with
+  `python scripts/video_intel.py index` if missing.
+
+### Full run (~1 minute, a few cents of Voyage tokens)
+
+```bash
+pytest tests/evals/ -v -s
+```
+
+The `-s` flag is important — the harness prints a per-metric report for
+each query. Suppressing stdout (pytest's default) hides the diagnostic
+that tells you *why* a query failed, not just that it did.
+
+### Smoke mode (Q01 only, ~3 seconds)
+
+```bash
+VIDEO_INTEL_EVAL_SMOKE=1 pytest tests/evals/ -v -s
+```
+
+Use while iterating on the harness itself, not on retrieval quality.
+
+## Metrics
+
+All four metrics are deterministic, no LLM judge required. Source:
+[`tests/evals/metrics.py`](../tests/evals/metrics.py).
+
+| Metric | What it measures | Gating |
+|--------|------------------|--------|
+| `RecallAtKMetric(k, threshold)` | Fraction of `expected_hits` `video_id`s appearing in top-k retrieved results. | Gating — test fails below threshold. |
+| `MRRMetric(threshold)` | Mean reciprocal rank of the first `expected_hit`. Score = 1/rank of first hit. | **Non-gating.** Informational signal only — dropped from pytest failure logic because a query can pass RecallAtK while MRR looks weak, and vice versa. |
+| `ChannelCoverageMetric(min_channels, threshold)` | Fraction of `expected_hits` channels that appear in retrieved results; also enforces absolute `min_channels` floor. | Gating. Cross-channel queries rely on this. |
+| `TimestampPrecisionMetric(tolerance_sec, threshold)` | For each expected hit, does any retrieved chunk for that video land within `[start - tol, end + tol]`? | Gating. Looser tolerance for mindmap-sourced entries. |
+
+A query passes iff all *gating* metrics meet their per-query thresholds.
+MRR is logged for diagnosis but doesn't fail the test.
+
+Metric thresholds are per-query (in `dimensions`), not global. This lets
+the dataset calibrate by query type — baselines expect higher recall
+than synthesis queries.
+
+## Current Baseline (2026-04-19)
+
+**1 of 25 queries pass all gating metrics.** Q15 ("Opus 4.7, Gemma 4,
+Sonnet 4.6") is the only passing query — exact model-name overlap between
+query and content lets BM25 dominate and hybrid win. Full diagnosis in
+[ADR-0017](adr/ADR-0017-kb-layer-strategy.md).
+
+Query-type breakdown:
+
+| Query type | Count | Avg recall | Target | Status |
+|------------|-------|------------|--------|--------|
+| Single-channel baseline | 10 | ~11% | 75% | Far below |
+| Cross-channel comparative | 10 | ~25% | 50–70% | Below |
+| Cross-channel synthesis | 5 | ~5% | 30–50% | Far below |
+
+Primary failure mode is **vocabulary mismatch**: queries use conceptual
+vocabulary ("reliable agents", "context engineering") while content uses
+creator vocabulary ("Ralph Wiggum", "Factorio parallel sessions"). This
+is the justification for the staged KB-layer interventions in ADR-0017.
+
+## Adding or Changing Queries
+
+Per ADR-0017, the dataset is frozen. If you need a new query:
+
+1. Grep the transcript corpus for the key phrase to confirm grounding —
+   don't invent hits the retrieval layer can't find even with perfect
+   recall.
+2. Record `manual_verified` or `concept_augmented_verified` provenance
+   honestly.
+3. Calibrate thresholds against the closest existing query of the same
+   `query_type`.
+4. Open an ADR update (or a new ADR if the change is structural) citing
+   the reason. Don't silently edit the YAML.
+
+Changes that *don't* need an ADR: fixing a typo in a query string,
+correcting a wrong `video_id` (grounding error), adjusting `key_phrase`
+to match actual transcript text. These are corrections, not
+recalibrations.
+
+## Extending the Harness
+
+The harness at
+[`tests/evals/test_search_quality.py`](../tests/evals/test_search_quality.py)
+is parametrized over the YAML. Adding a metric is a two-step change:
+
+1. Implement it in `tests/evals/metrics.py` as a `BaseMetric` subclass
+   with `measure`, `a_measure`, `is_successful`, and a `__name__`
+   property.
+2. Wire it into `_build_metrics()` in the harness, reading its
+   thresholds from the per-query `dimensions` dict.
+
+For LLM-judge (G-Eval) metrics, use DeepEval's `GEval` class and pass
+the `GEMINI_API_KEY`. This is Stage 3 prerequisite work per ADR-0017.
+
+## See Also
+
+- [ADR-0017 — Staged KB-Layer Strategy](adr/ADR-0017-kb-layer-strategy.md)
+- [ADR-0013 — Hybrid Search RRF Fusion](adr/ADR-0013-hybrid-search-rrf-fusion.md)
+- [`docs/search-internals.md`](search-internals.md) — retrieval pipeline
+  the eval measures against.
+- [DeepEval custom metrics docs](https://deepeval.com/docs/metrics-custom)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ Last verified: 2026-04-19
 
 | Suite | Directory | What it guarantees | How to run |
 |-------|-----------|--------------------|------------|
-| Unit / integration | [`tests/`](../tests/) | Code correctness — parsing, idempotency, error handling, CLI flags. Runs in seconds. | `pytest tests/ -v` (excluding `tests/evals/`) |
+| Unit / integration | [`tests/`](../tests/) | Code correctness — parsing, idempotency, error handling, CLI flags. Runs in seconds. | `pytest tests/ --ignore=tests/evals -v` |
 | Retrieval eval | [`tests/evals/`](../tests/evals/) | Retrieval **quality** against 25 frozen grounded queries. Runs Voyage API, ~1 min and a few cents. | `pytest tests/evals/ -v -s` |
 | Search CLI smoke grid | [`evals/search-eval-queries.md`](../evals/search-eval-queries.md) | Human-run sanity grid for CLI features (`--preview`, `--min-similarity`, `--limit`, dedup). Prose benchmark, not pytest. | Read the file, run queries manually, score 0/1/2. |
 


### PR DESCRIPTION
## Summary

Stage 0 of the staged KB-layer plan: promote the scattered 2026-04-16 scratch notes under `work/` into durable, discoverable documentation so a fresh clone of the repo can answer these three questions from `docs/` alone:

1. *How do I run the tests and why does this project use DeepEval?* → `docs/testing.md`
2. *Where is this project's retrieval layer going?* → `docs/adr/ADR-0017-kb-layer-strategy.md`
3. *How do I configure CE workflows for review?* → `compound-engineering.local.md`

**Stacked on #13.** After #13 merges, this PR's base auto-switches to `main`.

## What's inside

| File | Role |
|------|------|
| `docs/testing.md` | Operational testing explainer — why DeepEval, how to run, how to read the 1/25 baseline, how to add queries. Flat top-level peer to `docs/search-internals.md`. |
| `docs/adr/ADR-0017-kb-layer-strategy.md` | Canonical decision record. Stages 1–3 defined. Cognee rejected. Eval is the gate at every stage. |
| `docs/brainstorms/2026-04-19-kb-layer-staged-experiments-brainstorm.md` | Promotes & supersedes the two 2026-04-16 `work/` scratch notes. Preserves the A/B/C/D option analysis. |
| `compound-engineering.local.md` | Wires `/workflows:review` to five review agents (kieran-python, security-sentinel, performance-oracle, architecture-strategist, agent-native) with project-specific review context. |
| `CLAUDE.md` | +8 lines: Testing reference, KB-layer direction reference. Pytest snippets split between unit/integration and eval suite. |
| `docs/adr/README.md` | Index extended from ADR-0012 through ADR-0017 (was stale). |

## Why this shape (stacked on #13)

The docs reference `tests/evals/golden_dataset.yaml` and `tests/evals/metrics.py` specifically. Shipping the docs before the harness would leave broken links; shipping them together in one huge PR buries the harness design in markdown review. Two PRs, stacked, one review focus each.

## Strategic note (the interesting part)

ADR-0017 does not pick a winner between LightRAG and LLM Wiki. It stages them:

- **Stage 1** — query expansion via existing `taxonomy.json` aliases (hours–days, zero infra). Cheapest test of the vocabulary-mismatch hypothesis that the 1/25 baseline exposed.
- **Stage 2** — LightRAG (~1 week). Only if Stage 1 uplift is insufficient. Graph alias propagation is the heavy version of Stage 1.
- **Stage 3** — LLM Wiki synthesis (~1 week). Addresses the orthogonal 5% synthesis-query baseline. Parallel-safe with Stage 2.

The original 2026-04-16 brainstorm recommended Wiki + eval as the gate. The eval ran. It exposed recall as the dominant failure mode before synthesis is even a bottleneck. Staging is the refinement that honors the brainstorm's own "let the benchmark decide" rule.

## Testing

- Markdown-only; no code changes.
- `docs/testing.md` commands verified against the harness in #13 (`pytest tests/evals/ --collect-only` passes; 25 tests parametrize).
- `compound-engineering.local.md` YAML frontmatter validated structurally; first real exercise happens when `/workflows:review` runs against this PR.

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: docs-only PR. The compound-engineering.local.md file is read by the /workflows:review skill on demand, not at runtime.`

## Follow-ups (intentionally out of scope)

- Stage 1 tactical plan at `docs/plans/2026-04-19-feat-kb-stage1-query-expansion-plan.md` — to be produced via `/workflows:plan` after this lands.
- G-Eval metrics for `position_diversity` and `essay_coverage` — Stage 3 prerequisite.
- Timestamp-precision audit for `seankochel` mindmap-sourced gold entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)