### PR TITLE
refactor(evals): replace MRR gating string-match with gating: bool attribute

### DIFF
--- a/tests/evals/metrics.py
+++ b/tests/evals/metrics.py
@@ -36,6 +36,8 @@ class RecallAtKMetric(BaseMetric):
     the score; extra retrieved videos beyond the expected set do not penalize.
     """
 
+    gating: bool = True
+
     def __init__(self, k: int, threshold: float):
         self.k = k
         self.threshold = threshold
@@ -77,6 +79,11 @@ class MRRMetric(BaseMetric):
     Score = 1/rank of the first expected hit (1.0 if at rank 1, 0.5 at rank 2,
     etc.). Score = 0.0 if no expected hit appears in results at all.
     """
+
+    # Non-gating: informational signal only. A query can legitimately pass
+    # RecallAtK while MRR looks weak (expected hits present but not at top
+    # ranks), and vice versa — so MRR score never fails the test.
+    gating: bool = False
 
     def __init__(self, threshold: float):
         self.threshold = threshold
@@ -126,6 +133,8 @@ class ChannelCoverageMetric(BaseMetric):
     videos found) while channel_coverage fails (diversity missing).
     """
 
+    gating: bool = True
+
     def __init__(self, min_channels: int, threshold: float):
         self.min_channels = min_channels
         self.threshold = threshold
@@ -173,6 +182,8 @@ class TimestampPrecisionMetric(BaseMetric):
     expected range. One retrieved hit can satisfy multiple expected hits
     for the same video if their ranges overlap.
     """
+
+    gating: bool = True
 
     def __init__(self, tolerance_sec: int, threshold: float):
         self.tolerance = tolerance_sec

--- a/tests/evals/test_metrics.py
+++ b/tests/evals/test_metrics.py
@@ -1,0 +1,24 @@
+"""Unit tests for metric-class contracts (not per-query behavior).
+
+Per-query scoring is tested in `test_search_quality.py`. This module
+locks contracts that the parametrized harness can only verify
+indirectly — in particular, which metrics are gating vs. informational.
+"""
+
+from __future__ import annotations
+
+from .metrics import (
+    ChannelCoverageMetric,
+    MRRMetric,
+    RecallAtKMetric,
+    TimestampPrecisionMetric,
+)
+
+
+def test_gating_contract() -> None:
+    """Only MRR is non-gating. A stray flip would silently start failing
+    tests on an informational signal — guard the contract explicitly."""
+    assert RecallAtKMetric(k=10, threshold=0.5).gating is True
+    assert ChannelCoverageMetric(min_channels=1, threshold=0.5).gating is True
+    assert TimestampPrecisionMetric(tolerance_sec=30, threshold=0.5).gating is True
+    assert MRRMetric(threshold=0.25).gating is False

--- a/tests/evals/test_search_quality.py
+++ b/tests/evals/test_search_quality.py
@@ -86,8 +86,9 @@ def test_retrieval_quality(gold: dict[str, Any], search_context: tuple[Path, dic
     for metric in metrics:
         metric.measure(test_case)
         scores[metric.__name__] = (metric.score, metric.success, metric.reason)
-        if not metric.success and metric.__name__ != "MRR":
-            # MRR is informational (non-gating); all others are gates
+        if not metric.success and metric.gating:
+            # Non-gating metrics (e.g. MRR) are informational only — their
+            # score prints in the diagnostic report but never fails the test.
             failures.append(f"{metric.__name__}: {metric.reason} (score={metric.score:.3f})")
 
     # Always print the full per-metric report for visibility


### PR DESCRIPTION
Closes #16.

## Summary

The harness previously distinguished gating vs informational metrics via string-match on `metric.__name__`:

```python
if not metric.success and metric.__name__ != "MRR":
    # MRR is informational (non-gating); all others are gates
    failures.append(...)
```

Fragile: any new non-gating metric (e.g. the future G-Eval `essay_coverage` per ADR-0017 Stage 3) would require extending the string comparison in the harness.

## Change

Each `BaseMetric` subclass in `tests/evals/metrics.py` now declares a class-level `gating: bool`:
- `RecallAtKMetric.gating = True`
- `ChannelCoverageMetric.gating = True`
- `TimestampPrecisionMetric.gating = True`
- `MRRMetric.gating = False` (with a comment explaining *why* informational)

Harness reads `metric.gating` directly:

```python
if not metric.success and metric.gating:
    failures.append(...)
```

The decision now lives with the metric, which is where it belongs.

## Testing

- [x] `pytest tests/evals/ --collect-only` → 25 tests collect (0.11s)
- [x] `ruff check tests/evals/` → clean
- [x] `ruff format tests/evals/ --check` → all 5 files already formatted
- [x] `VIDEO_INTEL_EVAL_SMOKE=1 pytest tests/evals/ -v -s` → Q01 still fails on the same 3 gating metrics (`RecallAt10`, `ChannelCoverage>=3`, `TimestampPrecision`). MRR still shown in diagnostic report, still not in failure list. Behavior unchanged.

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: internal refactor with no runtime or user-visible behavior change.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)