### PR TITLE
chore(release): bump version to 1.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "video-intel",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "YouTube video intelligence via Gemini: channel scanning, rich multimodal transcripts with on-screen content, concept taxonomy, hybrid search, and Bosnian/Croatian/Serbian subtitle translation. Two independent skills in one plugin.",
   "author": {
     "name": "Daniel Zivkovic"


### PR DESCRIPTION
Version bump for v1.9.0 release.

Adds nugget CLI for cross-creator synthesis. See [ADR-0018](docs/adr/ADR-0018-nugget-cli-cross-creator-synthesis.md) and merged [#29](https://github.com/dzivkovi/video-intel/pull/29).