### PR TITLE
docs(claude-md): add Parallel Sessions rule for unfamiliar working tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,11 @@ Session plans are stored in `plans/` (configured via `.claude/settings.json`). P
 
 Solved problems are recorded in `docs/solutions/` following the three-bucket rule (living / historical / decision records).
 
+## Parallel Sessions
+
+- **Suspect parallel workers when the working tree is unfamiliar.** If you find untracked files you did not create, your branch differs from session-start, or `git status` shows changes you did not make, another Claude session is likely operating on the same checkout. Do **not** stash, checkout, or reset to "clean up" — that overwrites the other worker's in-progress changes. Instead, isolate via `git worktree add ../<repo>-<feature> <your-branch>` and continue from the worktree. The shared `.git` dir is safe; only the working tree needs isolation. *Why:* parallel Claude sessions are not coordinated by Compound Engineering or any hook, so without a worktree they fight over a single index/HEAD and one will silently lose work. Burned once on 2026-04-25 when issue #36 work and `feat/skip-shorts-and-prune` raced and the other worker had to WIP-stash the in-flight changes onto a branch.
+- **CE has `ce-worktree` but does not auto-invoke it.** Phrasings like "create a worktree" trigger the skill explicitly; otherwise sessions share the working tree. If you anticipate parallel work (multiple open issues, side-by-side feature branches), kick off with `ce-worktree` rather than waiting to discover the conflict.
+
 ## Code Review Guardrails
 
 Rules for review agents (auto-selected by `/ce-code-review`) and for anyone cutting a PR. These are the non-obvious checks — the general "does it work, does it have tests" bar is assumed.


### PR DESCRIPTION
## Summary

Adds a *Parallel Sessions* section to [CLAUDE.md](https://github.com/dzivkovi/video-intel/blob/main/CLAUDE.md) codifying the recovery pattern that worked when two Claude sessions raced on this checkout tonight (issue #36 work vs. `feat/skip-shorts-and-prune`).

## Why

Compound Engineering has the [`ce-worktree`](https://github.com/EveryInc/compound-engineering-plugin/) skill but does not auto-invoke it on session start. Without an explicit "create a worktree" instruction, parallel Claude sessions fight over a single index/HEAD and one will silently lose in-flight work. Tonight that happened: my staged changes for issue #36 had to be WIP-stashed onto a branch by the other session before they could continue. The recovery (manual `git worktree add`) worked, but only because I noticed and recovered.

The rule turns that recovery into a written contract so the *next* agent doesn't need to rediscover it.

## What changes

- **`CLAUDE.md`** — adds a *Parallel Sessions* section (5 lines + heading) between *Workflows* and *Code Review Guardrails*.
  - Rule 1: when working tree is unfamiliar, suspect a parallel worker; isolate via `git worktree add` rather than stash/checkout/reset.
  - Rule 2: CE's `ce-worktree` skill is opt-in. Anticipated parallel work should kick off with the skill rather than waiting for the conflict.

No code, no test, no schema change. Pure docs.

## Test plan

- [x] CLAUDE.md renders cleanly (no broken markdown)
- [x] Section ordering preserved (Workflows → Parallel Sessions → Code Review Guardrails)
- [x] No content overlap with existing sections

## Origin

Tonight's `wip/enabled-flag-issue-36` (PR #38) race with `feat/skip-shorts-and-prune` (PR #37 still open). Documented in passing in PR #38's body and the docs/solutions doc shipped with it.