### PR TITLE
docs(specs): move Parallel Sessions rule into agent-rules.md §4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,11 +237,6 @@ Session plans are stored in `plans/` (configured via `.claude/settings.json`). P
 
 Solved problems are recorded in `docs/solutions/` following the three-bucket rule (living / historical / decision records).
 
-## Parallel Sessions
-
-- **Suspect parallel workers when the working tree is unfamiliar.** If you find untracked files you did not create, your branch differs from session-start, or `git status` shows changes you did not make, another Claude session is likely operating on the same checkout. Do **not** stash, checkout, or reset to "clean up" — that overwrites the other worker's in-progress changes. Instead, isolate via `git worktree add ../<repo>-<feature> <your-branch>` and continue from the worktree. The shared `.git` dir is safe; only the working tree needs isolation. *Why:* parallel Claude sessions are not coordinated by Compound Engineering or any hook, so without a worktree they fight over a single index/HEAD and one will silently lose work. Burned once on 2026-04-25 when issue #36 work and `feat/skip-shorts-and-prune` raced and the other worker had to WIP-stash the in-flight changes onto a branch.
-- **CE has `ce-worktree` but does not auto-invoke it.** Phrasings like "create a worktree" trigger the skill explicitly; otherwise sessions share the working tree. If you anticipate parallel work (multiple open issues, side-by-side feature branches), kick off with `ce-worktree` rather than waiting to discover the conflict.
-
 ## Code Review Guardrails
 
 Rules for review agents (auto-selected by `/ce-code-review`) and for anyone cutting a PR. These are the non-obvious checks — the general "does it work, does it have tests" bar is assumed.

--- a/specs/agent-rules.md
+++ b/specs/agent-rules.md
@@ -45,6 +45,7 @@
 * **Don't rush commits.** Wait for peer review before committing if we are still mid-discussion. The cost of a follow-up commit is nothing; the cost of an unwanted commit is context loss and noisy history.
 * **Revert on failure.** If you break the test suite while iterating, `git reset --hard` back to the last green state rather than guessing fixes by overwriting files. If there are uncommitted changes you did not create, confirm before resetting.
 * **Execution strategy.** Default to sequential work for coupled changes: write one file, test it, verify, move on. Use parallel sub-agents only when tasks are truly independent and touch separate files.
+* **Worktrees for parallel sessions.** When the working tree is unfamiliar (untracked files you did not create, branch differs from session start, `git status` shows changes you did not make), suspect a concurrent Claude session. Do not stash, checkout, or reset; that overwrites the other session's in-flight work. Isolate via `git worktree add ../<repo>-<feature> <your-branch>` and continue from the worktree (shared `.git` is safe, only the working tree needs isolation). CE's `ce-worktree` skill is opt-in, so invoke it proactively when parallel work is anticipated rather than recovering after the conflict. *Why:* parallel Claude sessions share one index/HEAD without a worktree, so one will silently lose work.
 
 ## 5. Architectural Authority
 


### PR DESCRIPTION
## Summary

Promotes the worktree-for-parallel-sessions rule from [`CLAUDE.md`](https://github.com/dzivkovi/video-intel/blob/main/CLAUDE.md) (repo-scoped) into [`specs/agent-rules.md`](https://github.com/dzivkovi/video-intel/blob/main/specs/agent-rules.md) §4 Git Hygiene (cross-repo agent rule). Worktree discipline applies to any repo where parallel Claude sessions can race; it is not video-intel-specific.

## Why move

Per the agent-rules.md preamble: *"Repo-specific carve-outs in CLAUDE.md override this file."* The Parallel Sessions rule is the opposite of a carve-out: it's a generic rule about how Claude should behave under any repo with parallel sessions, so its natural home is the cross-repo file. CLAUDE.md becomes a cleaner record of video-intel-specific constraints.

## Changes

- **`specs/agent-rules.md` §4**: add a `Worktrees for parallel sessions` bullet immediately after `Execution strategy` (both rules cover parallel work, so they sit together). Tighter wording than the CLAUDE.md original (5 sentences down from 7), no narrative or dated-incident reference, single `*Why:*` sub-clause.
- **`CLAUDE.md`**: remove the `Parallel Sessions` section so there is one source of truth.

## Why leaner

`specs/agent-rules.md` rules are compact one-liners with `*Why:*` sub-clauses. The prior CLAUDE.md version's "Burned once on 2026-04-25..." narrative was a session-context flourish that does not belong in a durable rule file. The principle (worktree before stash/checkout/reset) is what survives.

## Test plan

- [x] `ruff format .` clean
- [x] `ruff check .` All checks passed
- [x] `pytest -m "not integration" --ignore=tests/evals` 598 passed (no regressions, but docs-only diff so this is just a sanity check)
- [x] Section ordering preserved in both files; no broken markdown
- [x] Cross-link from CLAUDE.md is unnecessary because the rule now lives in the canonical agent-rules.md file that CLAUDE.md already cites in its top section

## Origin

Tonight's session: PR [#39](https://github.com/dzivkovi/video-intel/pull/39) added the rule to CLAUDE.md after the `wip/enabled-flag-issue-36` (#38) and `feat/skip-shorts-and-prune` (#37) parallel-worker race. User feedback in the same session: rule belongs in specs, not CLAUDE.md, and the wording was too apologetic for a rule file.