### PR TITLE
P2: docs(ops): meta.json schema + troubleshooting SOPs + skill failure-routing (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,11 @@ python scripts/video_intel.py --model gemini-2.5-pro transcript \
 On parse failure, the raw Gemini response is saved as a `.transcript.raw.txt`
 sidecar file for debugging.
 
+When a video does not process cleanly (unlisted, members-only, token-cap, hang, or a confabulated future-premiere stub), see the operator references:
+
+- [`docs/troubleshooting.md`](docs/troubleshooting.md) - failure scenarios, causes, and step-by-step recovery SOPs (including the captions/SRT bridge for unlisted videos).
+- [`docs/meta-json-schema.md`](docs/meta-json-schema.md) - the canonical meta.json field reference.
+
 ## Bosnian/Croatian/Serbian (BCS) Translation Utility
 
 A separate utility script for translating YouTube video audio into

--- a/docs/meta-json-schema.md
+++ b/docs/meta-json-schema.md
@@ -1,0 +1,59 @@
+# meta.json schema
+
+Every processed video has a `{date}-{slug}.meta.json` sidecar in its channel folder. This is the canonical reference for its fields. The shape has accreted over many issues; when you add a field, update this doc (it is the companion deliverable of any change that touches meta.json).
+
+`meta.json` is derived state, not a source of truth for content (the `.transcript.md` / `.mindmap.md` / `.concepts.json` are). It records identity, processing state, and error/skip bookkeeping so re-runs are idempotent and failures are diagnosable.
+
+## Field reference
+
+### Identity (who this video is)
+
+| Field | Type | Written by | Notes |
+|---|---|---|---|
+| `video_id` | str | scan, transcript, process | 11-char YouTube ID. **The identity key** - dedup and idempotency-checks key on this, not the slug ("video_id is identity, slug is decoration"). |
+| `video_url` | str | scan, process | Canonical `https://www.youtube.com/watch?v=<id>`. Kept separate from any Gemini Files API `media_uri`, which never persists to disk. |
+| `channel` | str | scan, process | Channel `name` from config.yaml (the output folder name). |
+| `title` | str | scan, process | Video title. |
+| `published` | str | scan, process | Publish date, `YYYY-MM-DD`. |
+| `published_source` | str | process (local files) | How the date was derived when not from the YouTube API (e.g. file mtime). |
+| `duration_seconds` | int | scan (`enrich_with_durations`) | Used by the Shorts filter and the long-video transcript guard. |
+| `alt_titles` | list[str] | dedupe | Titles a creator rotated through (A/B SEO); merged onto the canonical meta during `dedupe`. |
+
+### Processing state
+
+| Field | Type | Written by | Allowed values / notes |
+|---|---|---|---|
+| `processed` | str (ISO-8601) | every writer | Last-processed timestamp. |
+| `model` | str | mindmap, transcript | Gemini model used. |
+| `modes_completed` | list[str] | every writer | Subset of `scan`, `transcript`, `mindmap`, `concepts`. Append-only via `update_meta`. |
+| `mindmap_source` | str | mindmap | `transcript` or `video` - what the mindmap was built from (issue #54). |
+| `mindmap_source_status` | str | mindmap | `partial` when the source transcript was non-healthy; absent otherwise. |
+| `prompt` / `source_prompt` | str | mindmap | Mindmap prompt name used. |
+
+### Transcript
+
+| Field | Type | Written by | Allowed values / notes |
+|---|---|---|---|
+| `transcript_status` | str | transcript writers | `ok` (chunked) / `complete` (single-shot, captions) = **healthy** (`_HEALTHY_TRANSCRIPT_STATUSES`); `partial` (salvaged / thin chunks) = degraded. Keep this set in sync with the writers. |
+| `transcript_source` | str | transcript writers | `gemini` (multimodal, default) / `youtube_captions` (caption-derived, speech-only) / `local_file` (uploaded MP4). Issue #60. Provenance flag - fidelity is signalled here, not by degrading `transcript_status`. |
+| `captions_is_generated` | bool | captions path | `true` for auto-generated ASR captions, `false` for a manual track. Issue #60. |
+| `transcript_failover_reason` | str | captions failover | Why `auto` fell back to captions (the Gemini error / `prompt=0` / parse failure). Issue #60. |
+| `transcript_recovery` | str | salvage path | `salvaged_sections` when a partial transcript was recovered from malformed JSON. |
+| `transcript_parse_error` | str | salvage / error | The JSON parse error message. |
+| `transcript_warning` | str | salvage path | Human-readable salvage warning. |
+| `transcript_chunks` / `transcript_chunk_minutes` / `transcript_thin_chunks` | int | chunked path | Chunked-transcript bookkeeping (count, window size, count of sub-50%-coverage chunks). |
+
+### Skip and error bookkeeping
+
+| Field | Type | Written by | Notes |
+|---|---|---|---|
+| `skip_modes` | list[str] | `mark-skip` | Per-mode skip (issue #42): any subset of `mindmap` / `transcript` / `concepts`. **Wins over `skip`** when both exist. |
+| `skip` | bool | manual / legacy | Legacy full-skip. Honored only when `skip_modes` is absent. |
+| `skip_reason` | str | `mark-skip` | Free-text bookkeeping for why a mode was skipped. |
+| `last_error` | str \| null | every error path | The last error message, or `null`. |
+
+## Minimal vs full meta
+
+The transcript-first writer creates a **minimal** meta (only `processed`, `transcript_status`, `modes_completed`, `last_error`) before the scan loop fills in identity. A confabulation stub or a transcript-only run can therefore leave an **identity-less** meta with no `video_id`/`title`/`video_url`. This quietly conflicts with the "video_id is identity" rule and makes cleanup harder.
+
+**Recommendation:** writers should populate `video_id`, `video_url`, `title`, and `published` on first write. Code that looks a video up by identity must tolerate a legacy minimal meta (fall back to the slug) but should not produce new ones.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,72 @@
+# Troubleshooting: scan/transcript failure scenarios and recovery SOPs
+
+Operator reference for the failure modes a scan hits in practice, each with its cause and a step-by-step recovery. These are documented procedures, not folklore - when a video does not process, find its symptom below.
+
+## Quick reference
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| Scan never finds a video that exists | **Unlisted** (not in the uploads feed) | manual `process --url`/`process --file`, or the SRT bridge below |
+| `403 PERMISSION_DENIED` | **Members-only / gated** | download via membership, then `process --file` |
+| `400 INVALID_ARGUMENT`, fails fast | **Token cap** on a long video (single-shot transcript) | `process --url --chunk-minutes 50`, or `transcript_source: auto` |
+| Transcript call hangs for many minutes | **Gemini stall** on a long/dense video | per-channel time cap / `mark-skip --mode transcript` / blocklist |
+| Tiny transcript, `prompt=0`, looked "complete" | **Future/scheduled premiere** confabulated | the confab guard now discards it; delete any old stub; see #70 pre-flight |
+| Two mindmaps / metas for one video | **Title rotation** (A/B SEO) | `dedupe` |
+
+## Scenarios
+
+### Unlisted videos (scan cannot discover them)
+
+`scan` discovers videos via the channel **uploads playlist** and `search()`. The YouTube Data API never returns unlisted videos to a non-owner key, so **no scan change can find them** - this is a hard API limit, not a bug. Captions and direct-URL playback still work, so once you have the URL you have options. (#70 adds pre-flight detection so an unlisted/future video that *does* appear via another path is skipped before Gemini, but discovery stays manual.)
+
+Recovery options, cheapest first:
+1. **Captions** (`transcript_source: yt-captions` or `--transcript-source yt-captions`) - speech-only, `$0` Gemini. Works because `youtube-transcript-api` hits the per-video caption endpoint, which serves unlisted videos.
+2. **Full fidelity** - download via your access, save as `output_dir/<channel>/<videoId>.mp4`, then `process --file` (gets SCREEN/diarization).
+
+### Members-only / gated (`403 PERMISSION_DENIED`)
+
+Gemini cannot fetch members-only, paid, age-gated, or region-locked videos. `scan`/`mindmap --url`/`transcript --url` log the 403 and **exit 0** with a stub meta (`modes_completed: []`, `last_error: ...PERMISSION_DENIED...`). Always grep the run output for `PERMISSION_DENIED` before trusting exit 0.
+
+Recovery: download via membership to `output_dir/<channel>/<videoId>.mp4`, then `process --file --video-id <id> --title "..." --date YYYY-MM-DD`.
+
+### Token cap on long videos (`400 INVALID_ARGUMENT`, fails fast)
+
+A long video's single-shot structured-JSON transcript exceeds Gemini's input or output cap and is rejected immediately. Scan's transcript loop pre-filters videos over `transcript_max_duration_seconds` (default 2h). For manual runs:
+- **Chunk it:** `process --url URL --chunk-minutes 50` (each chunk is a separate Gemini call against the same upload, merged with offset-applied timestamps).
+- **Or fail over to captions:** set `transcript_source: auto` on the channel - on a token-cap failure it falls back to the caption track (issue #60).
+
+### Transcript hang (no output for many minutes)
+
+A Gemini transcript call stalls. Defenses:
+- A scan loop with a per-channel time cap moves on after the cap (a single hung video cannot deadlock the batch).
+- `mark-skip --url URL --mode transcript --reason "hang on Nh video"` stops retrying just the transcript while keeping mindmap/concepts.
+- Add the `video_id` to the channel's `skip_video_ids` to drop it before any Gemini call on future scans.
+
+### Confabulation on future/scheduled premieres (`prompt=0`)
+
+A channel publishes an announcement entry for a premiere that has not aired. It shows in the uploads feed, Gemini fetches a non-existent stream, ingests **zero** video tokens (`prompt=0`), confabulates a ~2 KB stub, and (before issue #60) the pipeline marked it `transcript_status: complete`. The **confabulation guard** (issue #60) now discards any `prompt=0` response so the garbage never lands.
+
+The governing principle: **the corpus indexes things that have happened, not things that will happen.** If you find old confabulated stubs, delete the `.transcript.md` + `.meta.json` and rescan after the premiere airs. Issue #70 adds the pre-flight metadata check that skips `liveBroadcastContent: upcoming` videos before Gemini.
+
+### Title rotation (duplicate metas)
+
+A creator A/B-tests titles, rotating the slug so the same `video_id` lands under two prefixes. Run `dedupe` (dry-run first) to merge the loser titles into `alt_titles` on the canonical meta and remove the duplicate artifacts; then re-run `taxonomy-build` and `index --force`.
+
+## SOP: SRT bridge for an unlisted/captioned video
+
+When a wanted video is unlisted (or you just want a cheap speech-only index) and you do not need on-screen content, build a corpus transcript from its public caption track. As of issue #60 this is a one-command path - no manual file authoring:
+
+```bash
+# One-off: build a captions transcript and route it into the channel folder.
+python scripts/video_intel.py transcript --url "https://www.youtube.com/watch?v=<id>" \
+  --channel <channel> --transcript-source yt-captions
+
+# Then generate the mindmap (text-only, reads the on-disk transcript) and concepts:
+python scripts/video_intel.py mindmap --url "https://www.youtube.com/watch?v=<id>" --channel <channel>
+python scripts/video_intel.py concepts --channel <channel>
+
+# Finally re-index so it is searchable:
+python scripts/video_intel.py index --force
+```
+
+The transcript is flagged `transcript_source: youtube_captions` with a banner noting it is speech-only (no SCREEN/diarization). Replace it later with `process --file` if the on-screen detail turns out to matter. To make captions the standing behavior for a discovery-only channel, set `transcript_source: yt-captions` (or `auto` for Gemini-with-captions-failover) on the channel in `config.yaml`.

--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -168,6 +168,25 @@ Per video with `auto_transcript: all`: 1 expensive transcript call +
 path, used when no transcript is on disk). Wait for the user's go-ahead
 before running the real scan.
 
+## When processing fails
+
+A video that does not process cleanly almost always matches one of these
+scenarios. Route by symptom; the full causes + step-by-step recovery SOPs
+live in [`docs/troubleshooting.md`](../../docs/troubleshooting.md), and the
+meta.json fields these reference are in [`docs/meta-json-schema.md`](../../docs/meta-json-schema.md).
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| Scan never finds a video that exists | **Unlisted** (not in the uploads feed - a hard YouTube Data API limit) | manual `process --url`/`--file`, or `--transcript-source yt-captions` for a cheap captions index |
+| `403 PERMISSION_DENIED` (grep every URL run for it) | **Members-only / gated** | download via membership, then `process --file` |
+| `400 INVALID_ARGUMENT`, fails fast | **Token cap** on a long video | `process --url --chunk-minutes 50`, or set `transcript_source: auto` (captions failover) |
+| Transcript hangs for many minutes | **Gemini stall** | `mark-skip --mode transcript`, or add the id to `skip_video_ids` |
+| Tiny `prompt=0` transcript that looked "complete" | **Future/scheduled premiere** confabulated | the issue #60 confab guard now discards it; delete any old stub |
+| Two mindmaps/metas for one video | **Title rotation** | `dedupe` |
+
+Governing principle: **the corpus indexes things that have happened, not
+things that will happen** - skip future/scheduled premieres (`liveBroadcastContent: upcoming`).
+
 ## Model Selection
 
 The default model (`gemini-3-flash-preview` from config.yaml) works for most


### PR DESCRIPTION
Closes #69.

## What
Two operator references under `docs/` + README links + a SKILL.md failure-routing section. Pure documentation - no code changes.

- **`docs/meta-json-schema.md`** - canonical meta.json field reference (identity, processing state, transcript, skip/error), the healthy-status contract, and the minimal-vs-full (identity-less) meta gap.
- **`docs/troubleshooting.md`** - scenario → cause → recovery SOP for every failure mode the 2026-06-18 scan hit, plus the captions/SRT-bridge SOP and the "things that have happened, not will happen" principle.
- **SKILL.md** - a "When processing fails" symptom→recovery table linking both docs (so a future agent routes failures correctly).
- **README** - operator-references links.

## Verification
Files exist, all relative links resolve, and every referenced symbol/flag/command (`transcript_source`, `--transcript-source`, `mark-skip`, `skip_video_ids`, `_HEALTHY_TRANSCRIPT_STATUSES`, `dedupe`, ...) exists in the code. `liveBroadcastContent` is intentionally forward-referenced as #70's work. ruff clean (no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
