### PR TITLE
P2: feat(scan): pre-flight metadata check - skip future/unlisted before Gemini (#70)

### DIFF
--- a/scripts/video_intel.py
+++ b/scripts/video_intel.py
@@ -647,6 +647,53 @@ def enrich_with_durations(youtube, video_ids: list[str]) -> dict[str, str | None
     return durations
 
 
+def fetch_preflight_status(youtube, video_ids: list[str]) -> dict[str, dict]:
+    """Fetch per-video liveBroadcastContent + privacyStatus (issue #70).
+
+    Batches 50 ids per call - 1 quota unit per batch, the same cost as
+    ``enrich_with_durations`` (parts are free), so this is cheap to run on
+    every scan. Returns ``{video_id: {"live_broadcast_content": str|None,
+    "privacy_status": str|None}}``. Ids missing from the response (deleted,
+    gated) map to an empty dict so the caller's fail-safe keeps them - a
+    missing status is never a positive skip signal.
+    """
+    result: dict[str, dict] = {vid: {} for vid in video_ids}
+    if not video_ids:
+        return result
+    for i in range(0, len(video_ids), 50):
+        batch = video_ids[i : i + 50]
+        resp = youtube.videos().list(id=",".join(batch), part="snippet,status").execute()
+        for item in resp.get("items", []):
+            result[item["id"]] = {
+                "live_broadcast_content": item.get("snippet", {}).get("liveBroadcastContent"),
+                "privacy_status": item.get("status", {}).get("privacyStatus"),
+            }
+    return result
+
+
+def preflight_skip_reason(status: dict) -> str | None:
+    """Return why a video should be skipped before any Gemini call, or None to keep.
+
+    Issue #70, enforcing the principle "the corpus indexes things that have
+    happened, not things that will happen." Skips only on POSITIVE signals, so a
+    missing/empty status fails safe to KEEP (mirrors the duration fail-safe):
+
+    - ``liveBroadcastContent`` is ``upcoming`` or ``live``: a scheduled premiere
+      or in-progress stream that has not finished. Gemini fetches no playable
+      stream and confabulates a stub (the 2026-06-18 ``prompt=0`` failures).
+    - ``privacyStatus`` is present and not ``public`` (private/unlisted): scan
+      cannot reliably process these and Gemini's YouTube-URL ingestion is
+      public-only.
+    """
+    lbc = status.get("live_broadcast_content")
+    if lbc in ("upcoming", "live"):
+        return f"not yet aired (liveBroadcastContent={lbc})"
+    privacy = status.get("privacy_status")
+    if privacy and privacy != "public":
+        return f"non-public (privacyStatus={privacy})"
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Selective scanning: playlists and keywords
 # ---------------------------------------------------------------------------
@@ -3397,6 +3444,35 @@ def cmd_scan(args, config):
             raise
         for v in videos:
             v["duration_iso"] = durations.get(v["video_id"])
+
+        # Issue #70: pre-flight metadata filter. Drop videos that have not aired
+        # (scheduled premieres / live) or are non-public BEFORE any Gemini call.
+        # Gemini ingests no playable stream for these and confabulates a stub
+        # (the 2026-06-18 prompt=0 garbage). Piggybacks the duration call's quota
+        # tier (parts are free). Same quota-exhaustion fail-out as durations.
+        try:
+            statuses = fetch_preflight_status(youtube, [v["video_id"] for v in videos])
+        except HttpError as e:
+            if e.resp.status == 403 and _is_quota_exceeded(e):
+                log.error(
+                    "[%s] YouTube quota exhausted during pre-flight metadata check; aborting this channel.",
+                    ch_name,
+                )
+                continue
+            raise
+        kept = []
+        n_preflight = 0
+        for v in videos:
+            reason = preflight_skip_reason(statuses.get(v["video_id"], {}))
+            if reason:
+                log.info('  Pre-flight skip "%s": %s', v.get("title", v["video_id"]), reason)
+                n_preflight += 1
+            else:
+                kept.append(v)
+        if n_preflight:
+            log.info("  Pre-flight: skipped %d not-yet-aired/non-public video(s).", n_preflight)
+        videos = kept
+
         if skip_shorts:
             kept = [v for v in videos if not is_short(v["video_id"], v["duration_iso"])]
             n_skipped = len(videos) - len(kept)

--- a/scripts/video_intel.py
+++ b/scripts/video_intel.py
@@ -3448,8 +3448,10 @@ def cmd_scan(args, config):
         # Issue #70: pre-flight metadata filter. Drop videos that have not aired
         # (scheduled premieres / live) or are non-public BEFORE any Gemini call.
         # Gemini ingests no playable stream for these and confabulates a stub
-        # (the 2026-06-18 prompt=0 garbage). Piggybacks the duration call's quota
-        # tier (parts are free). Same quota-exhaustion fail-out as durations.
+        # (the 2026-06-18 prompt=0 garbage). This is a separate videos.list call
+        # from the duration enrich above, so it costs 1 quota unit per 50-id batch
+        # (negligible: ~4 units for a 200-video channel). Same quota-exhaustion
+        # fail-out as durations.
         try:
             statuses = fetch_preflight_status(youtube, [v["video_id"] for v in videos])
         except HttpError as e:

--- a/tests/test_preflight_metadata.py
+++ b/tests/test_preflight_metadata.py
@@ -1,0 +1,78 @@
+"""Tests for the pre-flight metadata filter (issue #70).
+
+Skip videos that have not aired (scheduled premieres / live) or are non-public
+BEFORE any Gemini call, so they never confabulate a prompt=0 stub.
+"""
+
+from unittest.mock import MagicMock
+
+import video_intel as vi
+
+
+class TestPreflightSkipReason:
+    def test_upcoming_is_skipped(self):
+        assert "not yet aired" in vi.preflight_skip_reason({"live_broadcast_content": "upcoming"})
+
+    def test_live_is_skipped(self):
+        assert "not yet aired" in vi.preflight_skip_reason({"live_broadcast_content": "live"})
+
+    def test_private_is_skipped(self):
+        assert "non-public" in vi.preflight_skip_reason({"privacy_status": "private"})
+
+    def test_unlisted_is_skipped(self):
+        assert "non-public" in vi.preflight_skip_reason({"privacy_status": "unlisted"})
+
+    def test_public_aired_is_kept(self):
+        assert vi.preflight_skip_reason({"live_broadcast_content": "none", "privacy_status": "public"}) is None
+
+    def test_empty_status_fails_safe_to_keep(self):
+        # Missing metadata is NOT a positive skip signal.
+        assert vi.preflight_skip_reason({}) is None
+
+    def test_none_values_fail_safe_to_keep(self):
+        assert vi.preflight_skip_reason({"live_broadcast_content": None, "privacy_status": None}) is None
+
+    def test_upcoming_takes_precedence_over_privacy(self):
+        reason = vi.preflight_skip_reason({"live_broadcast_content": "upcoming", "privacy_status": "public"})
+        assert "not yet aired" in reason
+
+
+class TestFetchPreflightStatus:
+    def _yt(self, items):
+        yt = MagicMock()
+        yt.videos.return_value.list.return_value.execute.return_value = {"items": items}
+        return yt
+
+    def test_parses_live_and_privacy(self):
+        yt = self._yt(
+            [
+                {"id": "a", "snippet": {"liveBroadcastContent": "none"}, "status": {"privacyStatus": "public"}},
+                {"id": "b", "snippet": {"liveBroadcastContent": "upcoming"}, "status": {"privacyStatus": "public"}},
+            ]
+        )
+        result = vi.fetch_preflight_status(yt, ["a", "b"])
+        assert result["a"] == {"live_broadcast_content": "none", "privacy_status": "public"}
+        assert result["b"]["live_broadcast_content"] == "upcoming"
+
+    def test_missing_id_maps_to_empty_dict(self):
+        yt = self._yt([{"id": "a", "snippet": {"liveBroadcastContent": "none"}, "status": {"privacyStatus": "public"}}])
+        result = vi.fetch_preflight_status(yt, ["a", "missing"])
+        assert result["missing"] == {}  # deleted/gated -> fail-safe keep
+
+    def test_empty_input_returns_empty(self):
+        assert vi.fetch_preflight_status(MagicMock(), []) == {}
+
+    def test_batches_over_fifty(self):
+        # 120 ids -> 3 batches of <=50; assert the API was called 3 times.
+        yt = MagicMock()
+        yt.videos.return_value.list.return_value.execute.return_value = {"items": []}
+        vi.fetch_preflight_status(yt, [f"v{i}" for i in range(120)])
+        assert yt.videos.return_value.list.return_value.execute.call_count == 3
+
+    def test_end_to_end_filter_via_reason(self):
+        # The two functions compose: a fetched upcoming video yields a skip reason.
+        yt = self._yt(
+            [{"id": "prem", "snippet": {"liveBroadcastContent": "upcoming"}, "status": {"privacyStatus": "public"}}]
+        )
+        status = vi.fetch_preflight_status(yt, ["prem"])["prem"]
+        assert vi.preflight_skip_reason(status) is not None

--- a/tests/test_skip_long_videos.py
+++ b/tests/test_skip_long_videos.py
@@ -159,6 +159,8 @@ def _scan_setup_with_transcript(monkeypatch, videos, durations=None):
         return dict.fromkeys(video_ids) | {k: v for k, v in durations.items() if k in video_ids}
 
     monkeypatch.setattr(vi, "enrich_with_durations", fake_enrich)
+    # Issue #70: stub the new pre-flight metadata call (keep all videos).
+    monkeypatch.setattr(vi, "fetch_preflight_status", lambda _yt, ids: {vid: {} for vid in ids})
     monkeypatch.setattr(vi, "_is_youtube_short_url", lambda video_id: False)
 
     captured = {"mindmaps": [], "transcripts": []}
@@ -1011,6 +1013,7 @@ class TestSkipVideoIdsConfig:
             return dict.fromkeys(video_ids, "PT10M")
 
         monkeypatch.setattr(vi, "enrich_with_durations", recording_enrich)
+        monkeypatch.setattr(vi, "fetch_preflight_status", lambda _yt, ids: {vid: {} for vid in ids})
         monkeypatch.setattr(vi, "process_mindmap", lambda *a, **kw: ("p", "done"))
 
         config = {

--- a/tests/test_skip_shorts.py
+++ b/tests/test_skip_shorts.py
@@ -426,6 +426,32 @@ class TestCmdScanSkipShorts:
         assert "short1" in ids, "Short must be kept when skip_shorts=false"
         assert "long1" in ids
 
+    def test_preflight_drops_upcoming_before_process(self, tmp_path, monkeypatch):
+        """Issue #70 integration: an upcoming-premiere video is dropped before it
+        reaches processing; an aired public video still processes."""
+        videos = [
+            {"video_id": "premiere1", "title": "Upcoming Premiere", "published": "2026-04-15"},
+            {"video_id": "aired1", "title": "Aired Video", "published": "2026-04-15"},
+        ]
+        durations = {"premiere1": "PT10M", "aired1": "PT10M"}
+        captured = _scan_setup(monkeypatch, videos, durations=durations)
+        # Override the keep-all stub: premiere1 is an upcoming premiere.
+        monkeypatch.setattr(
+            vi,
+            "fetch_preflight_status",
+            lambda _yt, _ids: {
+                "premiere1": {"live_broadcast_content": "upcoming", "privacy_status": "public"},
+                "aired1": {"live_broadcast_content": "none", "privacy_status": "public"},
+            },
+        )
+
+        config = {"output_dir": str(tmp_path), "channels": [{"name": "ch", "url": "https://example.com/ch"}]}
+        vi.cmd_scan(_scan_args(), config)
+
+        ids = [v["video_id"] for v in captured["processed"]]
+        assert "premiere1" not in ids, "Upcoming premiere must be dropped before processing"
+        assert "aired1" in ids, "Aired public video must still process"
+
     def test_quota_exceeded_skips_channel_continues_to_next(self, tmp_path, monkeypatch):
         """Multi-channel: when channel A's enrich raises quotaExceeded, the
         scan must abort that channel cleanly (continue, not return) and still

--- a/tests/test_skip_shorts.py
+++ b/tests/test_skip_shorts.py
@@ -370,6 +370,9 @@ def _scan_setup(monkeypatch, videos, durations=None, raise_on_enrich=None):
         return dict.fromkeys(video_ids) | {k: v for k, v in durations.items() if k in video_ids}
 
     monkeypatch.setattr(vi, "enrich_with_durations", fake_enrich)
+    # Issue #70: cmd_scan now calls fetch_preflight_status right after enrich;
+    # stub it to empty status (keep all) so these tests' behavior is unchanged.
+    monkeypatch.setattr(vi, "fetch_preflight_status", lambda _yt, ids: {vid: {} for vid in ids})
     # Default URL check returns False (long-form) so cmd_scan tests don't hit
     # real YouTube. Tests that want a "short via URL" decision pass durations
     # under 60s so the duration short-circuit fires before the URL check.
@@ -468,6 +471,9 @@ class TestCmdScanSkipShorts:
             return dict.fromkeys(video_ids)
 
         monkeypatch.setattr(vi, "enrich_with_durations", flaky_enrich)
+        # Issue #70: the quota error is raised by enrich (channel A); channel B's
+        # enrich succeeds and then reaches the pre-flight call - stub it (keep all).
+        monkeypatch.setattr(vi, "fetch_preflight_status", lambda _yt, ids: {vid: {} for vid in ids})
 
         captured = {"processed": []}
 

--- a/tests/test_video_id_dedup.py
+++ b/tests/test_video_id_dedup.py
@@ -403,6 +403,7 @@ def test_scan_dry_run_does_not_call_alt_title_recorder(tmp_path, monkeypatch):
     # the None youtube client. Returning all-None durations means is_short()
     # falls through to the URL check, which is also stubbed below.
     monkeypatch.setattr(vi, "enrich_with_durations", lambda _yt, ids: dict.fromkeys(ids))
+    monkeypatch.setattr(vi, "fetch_preflight_status", lambda _yt, ids: {vid: {} for vid in ids})
     monkeypatch.setattr(vi, "_is_youtube_short_url", lambda _vid: False)
 
     rotated = [{"video_id": "v1", "title": "Rotated", "published": "2026-04-15"}]
@@ -463,6 +464,7 @@ def test_scan_without_dry_run_calls_alt_title_recorder_on_rotation(tmp_path, mon
     # the None youtube client. Returning all-None durations means is_short()
     # falls through to the URL check, which is also stubbed below.
     monkeypatch.setattr(vi, "enrich_with_durations", lambda _yt, ids: dict.fromkeys(ids))
+    monkeypatch.setattr(vi, "fetch_preflight_status", lambda _yt, ids: {vid: {} for vid in ids})
     monkeypatch.setattr(vi, "_is_youtube_short_url", lambda _vid: False)
 
     rotated = [{"video_id": "v1", "title": "Rotated", "published": "2026-04-15"}]


### PR DESCRIPTION
Closes #70.

## What
`cmd_scan` now runs a **pre-flight metadata filter** before any Gemini call: it fetches each candidate's `liveBroadcastContent` + `privacyStatus` and drops videos that have not aired (scheduled premieres / live) or are non-public.

## Why
The 2026-06-18 scan produced two garbage transcripts from **future-premiere announcements**: a video scheduled to air weeks later showed in the uploads feed, Gemini fetched no playable stream, ingested zero tokens (`prompt=0`), and confabulated a ~2 KB stub. The principle: **the corpus indexes things that have happened, not things that will happen.**

## How
- `fetch_preflight_status(youtube, ids)` - batched `videos().list(part="snippet,status")`, **1 quota unit per batch** (same tier as the existing duration call - parts are free), so it adds no meaningful cost.
- `preflight_skip_reason(status)` - pure helper; skips only on **positive** signals (`upcoming`/`live`, or `privacyStatus != public`). A missing/empty status **fails safe to KEEP** (mirrors the duration fail-safe), and the #60 confabulation guard remains the downstream net.
- Slotted into `cmd_scan` right after duration enrichment, with the same quota-exhaustion abort-this-channel handling.

## Tests & smoke
- 13 new tests (`tests/test_preflight_metadata.py`); existing cmd_scan tests updated to stub the new call parallel to their `enrich_with_durations` stubs. **877 pass**, ruff clean.
- **Gate 1 (real API):** the actual upcoming premiere `xw_xj_zcQo4` → SKIP (not yet aired); unlisted `zlLJRVFXCDI` → SKIP (non-public); public aired `R56RJFZBasQ` → KEEP.

## Scope note (deferred)
The issue's secondary "failover diagnostic" (log a metadata-derived cause on a *Gemini* failure) is **not** in this PR. The proactive pre-filter prevents the premiere/unlisted cases before Gemini, and the #60 confab guard catches anything that slips through, so the post-hoc diagnostic is lower value. Easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
