### PR TITLE
P2: feat(briefings): pdf export for catch-up briefings

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,24 @@ python scripts/video_intel.py nugget "second brain patterns" --output brief.md
 
 See [`examples/nugget-lightrag-vs-openbrain-architectural-tension.md`](examples/nugget-lightrag-vs-openbrain-architectural-tension.md) for a sample output.
 
+### Catch-up briefings (Markdown + PDF)
+
+Once a corpus is indexed, `briefings --unseen` builds a personalized "what should I watch" guide. It surfaces only videos that appear in no previous briefing (a strict set difference, so nothing is ever recommended twice), bounds them to a recency window, and ranks them by how well each one overlaps with an inferred interest profile in `_briefings/profile.yaml` (hand-edit that file to retune). It makes no Gemini calls and needs no `channels:` config: it is a deterministic read over what you have already ingested.
+
+```bash
+# Preview the ranked unseen set (writes nothing)
+python scripts/video_intel.py briefings --unseen --dry-run
+
+# Write a Markdown catch-up guide (top 30 unseen from the last 30 days)
+python scripts/video_intel.py briefings --unseen
+
+# Also write a clickable PDF beside the Markdown (needs the optional [pdf] extra)
+pip install -e ".[pdf]"
+python scripts/video_intel.py briefings --unseen --pdf
+```
+
+The `--pdf` flag is for reading on the go and sharing: it renders the same ranked set as a one-page-friendly PDF whose video titles and timestamped moments are bold, accent-colored hyperlinks that open YouTube at the exact second. It is purely additive, the Markdown is always written and remains the record of what has been surfaced. The PDF writer is self-contained ([`scripts/briefing_pdf.py`](scripts/briefing_pdf.py), ~90 lines on top of `reportlab`), so anyone who installs the plugin gets it with no external service.
+
 ## Prompt Customization
 
 Prompts live in `prompts/`. Each file is self-contained.

--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ pip install -e ".[pdf]"
 python scripts/video_intel.py briefings --unseen --pdf
 ```
 
-The `--pdf` flag is for reading on the go and sharing: it renders the same ranked set as a one-page-friendly PDF whose video titles and timestamped moments are bold, accent-colored hyperlinks that open YouTube at the exact second. It is purely additive, the Markdown is always written and remains the record of what has been surfaced. The PDF writer is self-contained ([`scripts/briefing_pdf.py`](scripts/briefing_pdf.py), ~90 lines on top of `reportlab`), so anyone who installs the plugin gets it with no external service.
+The `--pdf` flag is for reading on the go and sharing: it renders the ranked set as a one-page-friendly PDF whose video titles and timestamped moments are bold, accent-colored hyperlinks that open YouTube at the exact second. It is purely additive, the Markdown is always written and remains the record of what has been surfaced. The PDF writer is self-contained ([`scripts/briefing_pdf.py`](scripts/briefing_pdf.py), ~90 lines on top of `reportlab`), so anyone who installs the plugin gets it with no external service.
+
+`briefings --unseen` ranks deterministically; it is the candidate feed, not the final word. The richer, *curated* briefing - a named audience profile, a "watch these N" prioritization, pillar grouping, a "why it matters to you" line per video, and explicit signal/noise calls - is an editorial layer authored on top of that feed. See [`examples/catch-up-briefing-personalized-sample.pdf`](examples/catch-up-briefing-personalized-sample.pdf) for the target output; the curation layer that produces it directly is tracked in [#84](https://github.com/dzivkovi/video-intel/issues/84).
 
 ## Prompt Customization
 

--- a/examples/catch-up-briefing-personalized-sample.pdf
+++ b/examples/catch-up-briefing-personalized-sample.pdf
@@ -1,0 +1,274 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 25 0 R /F4 26 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=2w_vwQVvFmc)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 576.7 443.952 592.2 ] /Subtype /Link /Type /Annot
+>>
+endobj
+5 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=2w_vwQVvFmc&t=405s)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 500.7 87.21 512.7 ] /Subtype /Link /Type /Annot
+>>
+endobj
+6 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=2w_vwQVvFmc&t=772s)
+>> /Border [ 0 0 0 ] /Rect [ 161.12 500.7 186.69 512.7 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=2w_vwQVvFmc&t=1022s)
+>> /Border [ 0 0 0 ] /Rect [ 303.41 500.7 328.98 512.7 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=r4_KLZvHoaA)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 467.3 322.584 482.8 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=r4_KLZvHoaA&t=35s)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 391.3 87.21 403.3 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=r4_KLZvHoaA&t=186s)
+>> /Border [ 0 0 0 ] /Rect [ 224.74 391.3 244.75 403.3 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=r4_KLZvHoaA&t=604s)
+>> /Border [ 0 0 0 ] /Rect [ 379.26 391.3 404.83 403.3 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=A4zMyjkL0Dc)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 327.9 317.244 343.4 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=A4zMyjkL0Dc&t=90s)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 236.9 87.21 248.9 ] /Subtype /Link /Type /Annot
+>>
+endobj
+14 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=A4zMyjkL0Dc&t=353s)
+>> /Border [ 0 0 0 ] /Rect [ 237.27 236.9 257.28 248.9 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=A4zMyjkL0Dc&t=657s)
+>> /Border [ 0 0 0 ] /Rect [ 432.4 236.9 457.97 248.9 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=VzmMQWRhlBw)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 158 397.884 173.5 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=VzmMQWRhlBw&t=5s)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 82 87.21 94 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=VzmMQWRhlBw&t=265s)
+>> /Border [ 0 0 0 ] /Rect [ 215.06 82 234.8606 94 ] /Subtype /Link /Type /Annot
+>>
+endobj
+19 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=VzmMQWRhlBw&t=620s)
+>> /Border [ 0 0 0 ] /Rect [ 404.03 82 429.0975 94 ] /Subtype /Link /Type /Annot
+>>
+endobj
+20 0 obj
+<<
+/Annots [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 
+  14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R ] /Contents 32 0 R /MediaBox [ 0 0 612 792 ] /Parent 31 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+21 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=T17DYl_4Z-U)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 696.1 321.936 711.6 ] /Subtype /Link /Type /Annot
+>>
+endobj
+22 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=T17DYl_4Z-U&t=53s)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 620.1 87.21 632.1 ] /Subtype /Link /Type /Annot
+>>
+endobj
+23 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=T17DYl_4Z-U&t=721s)
+>> /Border [ 0 0 0 ] /Rect [ 216.16 620.1 241.73 632.1 ] /Subtype /Link /Type /Annot
+>>
+endobj
+24 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=T17DYl_4Z-U&t=1248s)
+>> /Border [ 0 0 0 ] /Rect [ 382.35 620.1 407.92 632.1 ] /Subtype /Link /Type /Annot
+>>
+endobj
+25 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+26 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+27 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.youtube.com/watch?v=h1MxhfZSTjo)
+>> /Border [ 0 0 0 ] /Rect [ 67.2 564.2 251.14 576.2 ] /Subtype /Link /Type /Annot
+>>
+endobj
+28 0 obj
+<<
+/Annots [ 21 0 R 22 0 R 23 0 R 24 0 R 27 0 R ] /Contents 33 0 R /MediaBox [ 0 0 612 792 ] /Parent 31 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+29 0 obj
+<<
+/PageMode /UseNone /Pages 31 0 R /Type /Catalog
+>>
+endobj
+30 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260626172924-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260626172924-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Your Viewing Guide - weekend catch-up) /Trapped /False
+>>
+endobj
+31 0 obj
+<<
+/Count 2 /Kids [ 20 0 R 28 0 R ] /Type /Pages
+>>
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2530
+>>
+stream
+Gau1/>BAQ-'$&o..<bW.Wh^udX)=JBa*,p*>,S8mgh&V-(RTk$=<tZ`TG>_A%tAag;Nbm"X:s4Z=;m&"(45lEIhb;#^S1OsPlTuKE;EK=@0BXf#STFRX%R\YFnGE*f\SV.q%8S&a<0CDGhim_E&%j\iN&OliF:bXI9`bi[3Gr)[!!/4b(IH.Xl3'l=$k3kD(TclKhn3l\]j#afkfXG;8%R^>I\uRB)I\(%nmj97\)"&p5Am6Fq!1jFJ]@MR":k<nRqLX<R5+CRoV=BTF!WBJeoJtF(n)*AL^4I4L5_j@D&#.A^3/<8,1`_[=ft!U@\S_+<!-SLEQC"mdN'UoN31GpKF2JSad$>I+c"]E7RPH+.8&4"(mi]T=Ra%i7qT?36oTj:fj;8n2mf)G!Ra0#Gj,/k?rte37nCi<U4N55-S8&r?lben8A_KDJLh"i)aMN#X][gd&JM0lOGef"XI31f1K:^_(8[l/%;uf;Tos.5DG)"it=B?VH#cd^m]j]E,"6VE8SWrBf<:FE)Ei#kKl3d"A4r#I,3Tng*iJ'8t*>qoPhe9iqh2LBOrf.1Tk_/49VE]X]/TeTUB'5R18'1;651j6Oj0O+4&=^U?'>"ZD'.]c(8&]ZDD3!G?a)t3TlZ/#[D8E<U'G&10ZR,K91B#._dA!d00J."dHe05Q(>u+-23).#!G[+5S&1pM:/XLlsoO!^?$V24\PbI<Jc5Y2i*U/Dn]#8/Ul+%1@@"+V*^D[H/6b2S@=pdG\T4UVn7^#*$X_.)o3)P:0,0m\1CK,``@KldhKR:ag1<?uUfpr_Y[P-jph!Na@HIeI"KKhYdHSla"Ol0;Ngt`RDUMV3a>W%\q=nHaZ<o6c+j,j*l_R9_FlZ-#mG8!ht8_%)"(WYlW1]c\=DnNS#C?CW-AkBIp]oM2o=QK]_CtOS`qGNH`:=rnAC#Wst*Pif9Mg4\miDn,E&\Pjk89/7H6T.EuLoQ&Zh`*l\fqjrsn+$->KD'[rUO]Dsa04;hTlY$d>I^%>o=;$uX['Ng>K;5L:PVieG=$n/bXX'QI$Ye\jsM,b%t-kPTrl%V_:3Wc'[7G&^m*)O5K"1RB,TaH5M8-2_Zk!>fYg;'F8R=s<UT9k?A++@]disil6+?T!Tl:tM4Ard7ABNYiMP0'XQfR#n[]9khBs-$FcKAeXY+#JRr.0=-oC#I:P>7,J9SNC9I><\"CBln<B3rH[mTPhT<^X6^5*8\cUb/7c0>iM0&D_VXf:db<GQmd8aDDIgYitk4(1/.ZAV+>eWWDuu$/"a$H_RZP.5%iPh_mUYrmAoEWC#%D7eS)j@^1I*BXJJ)W#K+7Ps$Nk"[$ieGU,&l#bmHA$F4)SA#-g'd`K;b5UOjG[j?EF2o<jbW7dq+-m,"SCPWPeN_.<3oc#^P%C%s"#&/ug7]7,B@QuU@:>\K_&f2"ph3K\tX^V[/7b5X1B/^nc9[QV'5g?9,mMN#,LVfO8edFLq];Ujf/or'0N-J+JZM_.b2H(qC%P)b>^&tV*6ph*&C2L%87'R#1()2kqm9N7roOE:?+j]\qkDnBM5a@W&t^a^Cd]#+8h=9[1K0W^]k_'VcKGegD?jlNh:&l4/=_<i.2SuSegg=B0S2/GVRI"DON+??r;do7apZp*5&NkQ&-aK1_?=.F//IB3ks7CZ?R:CBgcT9*)Ij0Kes[CZ@3dIe<Olet(td4+p`6Un%>Gq"ulK9)sg.c^aCG@fmQH1haIM[JMPB.#[FE!BAlq0Qobj3FNO:E_'?D2?VZY78UL0`iY#OA;O7j@k?ZE'IAVOU:.V>t;O]Ssjrmbs"/?A1JB$WApfq4Eh)8=N2jM#2N[r\ku\&f5c\Ug_G&-2;!LpoSVVIGA>Za3>0KAj6#9H0R*]GEE8;>q6dn2(Jnjk"^?31%WDV.O;49C\0MZBUB3:a<]J@6iMt<shaX2h)b8.smPKu1_lT]9<mnTGc1_@lJRgF1)3']:"XqOF,XZWj1+dB'r*9\JG@^*\(6l;*#K'Cug7O8]o-kYSj5;&X.T\GP)I<-lf1gENRuHSgN=Tp:EA;9749_^cR(9)\\XDkYJ=MW0mVCI6H^L#,o-P;lITc>=O-'hK91(]ZDcV8u-q=DOU7iODf#V;JeU(C<VSe`Ena@t\4kCHg+><;b.rk<l*?&N^_hUm0,OYc\Bf&][)40^U>$lkl_b-/%QJZ[7R<Y=?Sc"\Nr<Wu6_Kf]24uUp=%-\%#Xkf=F6q^LM\Trcs*2VC2!&^P7[$AYZ>B0K`c4Hu&g!*"<K6T.45Jc3+^,(?GP;J9>NlCJ;)\fbP0>mDI=1BSlbJtB3?55$/:1aj/CUI7`OWjZ4>(351o6p#$%5[/*/T1i@bR#ZT;7X<7\@d4Xd88*Hg\^q8f/WK_KJ$jn`&$J-Vtl57gfn0u+m'\\lO*8n?1QehIBMD8Kt0\p"!J+o-*r#q*KBeo@(L3a8N7d!rUtNr2`N@;-R$2kghk6rSBGa=D!iUukjV'2pcT*m(T8upD03:em)0\gUsOhFg^Eii5mdMZlX:/krs*i_Kb+~>endstream
+endobj
+33 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1244
+>>
+stream
+Gatm9;/b2I&:XAW3#$^Y2G5bRag+(r_$Q:U7CIBGJRX.\JWXW(0h&)f<A47B43E`B,]:8'MZ_*KFa)a!GP@68&3lsnZP)22$(&+(#_h@Y80#XR]Ru\bmrOPsDiW8-6;#8V#Rt`;,XX=)&U=:3RiXU8#QO"e7,J\LeG)ePkPdsp,r6)u!"6i+X"1]5>@";")uOl]Q*$krC3'F!#?ZHDZ2BKOB6Zn03$^)IF?HEt!b!pZ,Y9/T$#[[7n3g]*5d\iqnN2Qk>-^3P(`Se`@.n:8=$/E&gVQa*UDu4X&XL=NIKn8gG*nj(VYe/^pgChgA&#:'0HT1[qVl3IcnCg?rip%Ci+lFlgn[:u$AP=+->,S3a[m%@gnI>#'P,k5T^BLT3s3AZ[:G<\!C*I<`,$pT)YN!P_HNWJA6M!gjdYt/UYe6tl5G_!RDXG)E7G.DQP,Yhk3Z?L+m2aNiJ-/]54,ZA$PflSXd'!^f%b50nGt1)>Q_Ze2ubk,J^(Pfo)W[4Vnh_Rb6i+l:jTU%j,/+dX"bOr)P0LZk"h:'q$=.]LUbC+K@q63g.2]8D-R+eY\`XqXtc&4$@L<pCenR_^lBQV..keHa(3@c$AL!OW"Bm5K].3$L/0Si#4Dkj8OmFG''dq\kksR&5^tafU9DqX@)'O(C]MLYC&OVlYY>p_<Pig^#b;IIX22@j42pj,%S)<'Gl2<dQp,@$*-E6JiBZ[f4[[)*K'Q`[@bBYuqd)6'O(aDYSiqRMgJa)K$#uCXG=.Ir39<"hO'_jMVV^PXMPh1.`?_m`h28M+[B6B6cRXicR%=qK<\$bsF]\2G.!Vf#+-o!**INX&Y@+M@aeYPmAUuH*M=YUeim-F3)@3CX_EPV^d)qEW(I,LB^]a=VmBsnuD/7?t1<$0Lp45i@1!R@XH4NCAZcF685k.@s'jC1d?K[@Ml@`Tsh`YYT2J=-U:_$[&-KK:o86o@e1C-hB0=\4nYq6=V(WX*K%3I(&B(Nh^h#"[a\@J-OWaN:SPn2c?.9@?lM/7;H_ST74rN1diC/KYdC54t*dWS(o&fU._H[13`&cM0h)Gd*&f5D8p["ZT[\inhmq[9Y.MfrKDZXt*$Vq>HL-]eXF"]L:O<(0adW0PX*D_.IJ*)eAhq!Ye#f(U.Jf@mL[`K*^s.r;[;@O9;Wk7q_]Nqh>[>U\NTWsFt":p'[*Ij?G[*[l:de,\9!+9Tj^5U1`dB`a7H16,\M*)E[NftK>8P68M5!C`Du\G~>endstream
+endobj
+xref
+0 34
+0000000000 65535 f 
+0000000061 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000527 00000 n 
+0000000716 00000 n 
+0000000908 00000 n 
+0000001101 00000 n 
+0000001285 00000 n 
+0000001473 00000 n 
+0000001666 00000 n 
+0000001859 00000 n 
+0000002044 00000 n 
+0000002233 00000 n 
+0000002426 00000 n 
+0000002618 00000 n 
+0000002801 00000 n 
+0000002983 00000 n 
+0000003172 00000 n 
+0000003361 00000 n 
+0000003678 00000 n 
+0000003863 00000 n 
+0000004052 00000 n 
+0000004245 00000 n 
+0000004439 00000 n 
+0000004559 00000 n 
+0000004675 00000 n 
+0000004859 00000 n 
+0000005102 00000 n 
+0000005172 00000 n 
+0000005477 00000 n 
+0000005545 00000 n 
+0000008167 00000 n 
+trailer
+<<
+/ID 
+[<3162d1b67b7936f212c6a11295478a9d><3162d1b67b7936f212c6a11295478a9d>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 30 0 R
+/Root 29 0 R
+/Size 34
+>>
+startxref
+9503
+%%EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ vector = [
     "lancedb>=0.20",
     "voyageai>=0.3",
 ]
+pdf = [
+    "reportlab>=4",
+]
 dev = [
     "ruff",
     "pytest",

--- a/scripts/briefing_pdf.py
+++ b/scripts/briefing_pdf.py
@@ -1,0 +1,106 @@
+"""Self-contained PDF renderer for catch-up briefings (issue #82).
+
+A clickable, one-page-friendly PDF rendered from the SAME ranked set the
+Markdown briefing uses (``render_unseen_briefing`` in ``video_intel.py``).
+The design is deliberately lean - the only adornments are the three that
+create a tappable call-to-action: **bold**, an accent color, and a real
+hyperlink. No cover page, no recap section, no tables, no "featured" slot:
+the top-ranked item simply renders first.
+
+reportlab is an OPTIONAL dependency (``pip install -e ".[pdf]"``). Import
+this module lazily so the Markdown path stays dependency-light; callers
+catch ImportError and print an actionable install hint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from reportlab.lib.colors import HexColor
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import inch
+from reportlab.platypus import HRFlowable, Paragraph, SimpleDocTemplate
+
+ACCENT = "#c96442"  # the one color that signals "clickable"
+_INK = HexColor("#1a1a1a")
+_BODY = HexColor("#333333")
+_GRAY = HexColor("#777777")
+_RULE = HexColor("#e2e2e2")
+
+_TITLE = ParagraphStyle("bp_title", fontName="Helvetica-Bold", fontSize=19, leading=24, textColor=_INK, spaceAfter=3)
+_SUB = ParagraphStyle("bp_sub", fontName="Helvetica", fontSize=10, leading=14, textColor=_GRAY, spaceAfter=14)
+_VTITLE = ParagraphStyle(
+    "bp_vtitle", fontName="Helvetica-Bold", fontSize=12.5, leading=16, textColor=_INK, spaceBefore=11, spaceAfter=1
+)
+_META = ParagraphStyle("bp_meta", fontName="Helvetica", fontSize=9, leading=12, textColor=_GRAY, spaceAfter=3)
+_WHY = ParagraphStyle("bp_why", fontName="Helvetica", fontSize=11, leading=15.5, textColor=_BODY, spaceAfter=4)
+_JUMP = ParagraphStyle("bp_jump", fontName="Helvetica", fontSize=10.5, leading=16, textColor=_BODY, spaceAfter=2)
+
+
+def _esc(text: object) -> str:
+    """Escape text for reportlab's mini-markup parser (titles are creator-controlled)."""
+    return str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _link(url: str, label: str) -> str:
+    """Bold + accent-colored hyperlink - the tappable call-to-action."""
+    return f'<a href="{_esc(url)}" color="{ACCENT}"><b>{_esc(label)}</b></a>'
+
+
+def render_unseen_briefing_pdf(
+    ranked: Sequence[dict],
+    profile: dict,
+    out_path,
+    *,
+    lower,
+    upper,
+    link_extractor: Callable[[dict], list[tuple[str, str]]] | None = None,
+    today=None,
+) -> None:
+    """Write a clickable catch-up-briefing PDF to ``out_path``.
+
+    ``ranked`` items use the same keys as ``render_unseen_briefing``:
+    ``video_id, title, url, channel, published, score, matched_concepts``.
+    ``link_extractor(video) -> [(label, url), ...]`` supplies the timestamped
+    deep-links (the caller passes the same mindmap-link logic the Markdown
+    path uses, so the two renderers stay in lockstep without this module
+    importing from ``video_intel``).
+    """
+    doc = SimpleDocTemplate(
+        str(out_path),
+        pagesize=letter,
+        leftMargin=0.85 * inch,
+        rightMargin=0.85 * inch,
+        topMargin=0.7 * inch,
+        bottomMargin=0.6 * inch,
+        title=f"Catch-up briefing {lower.isoformat()} to {upper.isoformat()}",
+        author="video-intel",
+    )
+    story = [
+        Paragraph("Catch-Up Briefing: Unseen Videos", _TITLE),
+        Paragraph(
+            f"{lower.isoformat()} to {upper.isoformat()} &middot; {len(ranked)} video(s) "
+            "&middot; tap any orange link to jump to that moment",
+            _SUB,
+        ),
+    ]
+    if not ranked:
+        story.append(Paragraph("No unseen videos in this window.", _WHY))
+        doc.build(story)
+        return
+
+    for video in ranked:
+        story.append(Paragraph(_link(video["url"], video["title"]), _VTITLE))
+        meta = f"{_esc(video['channel'])} &middot; {_esc(video.get('published', ''))}"
+        if video.get("score"):
+            meta += f" &middot; relevance {video['score']:g}"
+        story.append(Paragraph(meta, _META))
+        if video.get("matched_concepts"):
+            story.append(Paragraph("Why: " + _esc(", ".join(video["matched_concepts"])), _WHY))
+        links = link_extractor(video) if link_extractor else []
+        if links:
+            story.append(Paragraph("  &middot;  ".join(_link(u, label) for label, u in links), _JUMP))
+        story.append(HRFlowable(width="100%", thickness=0.4, color=_RULE, spaceBefore=7, spaceAfter=1))
+
+    doc.build(story)

--- a/scripts/video_intel.py
+++ b/scripts/video_intel.py
@@ -6916,6 +6916,30 @@ def cmd_briefings(args, config):
     out_path.write_text(content, encoding="utf-8")
     print(f"Wrote catch-up briefing: {out_path} ({len(ranked)} videos)")
 
+    # --pdf is purely additive: the Markdown above stays the canonical
+    # seen-coverage record (load_seen_video_ids only parses *.md front matter),
+    # and the PDF is a shareable render of the SAME ranked set. The link
+    # extractor mirrors render_unseen_briefing's zero-score skip exactly so the
+    # two artifacts stay in lockstep.
+    if getattr(args, "pdf", False):
+        try:
+            from briefing_pdf import render_unseen_briefing_pdf
+        except ImportError:
+            log.error(
+                'PDF export needs reportlab. Install the optional extra: pip install -e ".[pdf]" '
+                "(or pip install reportlab). The Markdown briefing was written regardless."
+            )
+        else:
+            pdf_path = out_path.with_suffix(".pdf")
+
+            def _links(video):
+                return extract_mindmap_links(video.get("mindmap_path"), video["url"]) if video.get("score") else []
+
+            render_unseen_briefing_pdf(
+                ranked, profile, pdf_path, lower=lower, upper=upper, link_extractor=_links, today=today
+            )
+            print(f"Wrote catch-up briefing PDF: {pdf_path}")
+
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -7350,6 +7374,13 @@ Examples:
         default=DEFAULT_LIMIT,
         help=f"Cap the briefing to the top-N most relevant unseen videos (default {DEFAULT_LIMIT}). "
         "0 = no cap. Uncapped videos stay unseen for the next run.",
+    )
+    briefings_parser.add_argument(
+        "--pdf",
+        action="store_true",
+        help="Also write a clickable PDF (<date>-catch-up-unseen.pdf) beside the Markdown, "
+        'rendered from the same ranked set. Requires the [pdf] extra (pip install -e ".[pdf]"). '
+        "The Markdown is always written too - it remains the seen-coverage record.",
     )
 
     args = parser.parse_args()

--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -144,7 +144,7 @@ table is the canonical mapping — read it before picking a command.
 | "rebuild the index", "reindex after dedupe" | `index --force` | Write-path rebuild of LanceDB; query uses `video-intel-search` |
 | "prune shorts", "remove shorts", "too many shorts in my corpus" | `prune-shorts [--apply]` | **Always `--dry-run` first** — destructive on `--apply`; deletes mindmap/transcript/concepts/meta per Short |
 | "rebuild taxonomy", "update master vocabulary" | `taxonomy-build` | Derived artifact; rebuildable anytime |
-| "catch me up on what I missed", "what haven't I been briefed on", "videos I haven't seen yet", "generate a catch-up briefing", "fill the gaps in my viewing guides" | `briefings --unseen [--dry-run] [--since DATE] [--until DATE] [--limit N]` | Surfaces corpus videos absent from every existing `_briefings/*.md` `video_ids` list (strict set difference, never re-surfaced once briefed), within a default 30-day UTC window, ranked by overlap with the inferred profile in `_briefings/profile.yaml` and capped to the top `N` (default 30; `--limit 0` = no cap). `--dry-run` previews; otherwise writes `_briefings/<date>-catch-up-unseen.md`. Widen with `--since 120d` for a one-time backlog sweep. No Gemini, no `channels:` required. |
+| "catch me up on what I missed", "what haven't I been briefed on", "videos I haven't seen yet", "generate a catch-up briefing", "fill the gaps in my viewing guides", "give me the briefing as a PDF", "a briefing I can open on my phone / share" | `briefings --unseen [--dry-run] [--since DATE] [--until DATE] [--limit N] [--pdf]` | Surfaces corpus videos absent from every existing `_briefings/*.md` `video_ids` list (strict set difference, never re-surfaced once briefed), within a default 30-day UTC window, ranked by overlap with the inferred profile in `_briefings/profile.yaml` and capped to the top `N` (default 30; `--limit 0` = no cap). `--dry-run` previews; otherwise writes `_briefings/<date>-catch-up-unseen.md`. `--pdf` additionally writes a clickable `.pdf` beside it (bold, accent-colored, hyperlinked timestamps; needs the `[pdf]` extra). Widen with `--since 120d` for a one-time backlog sweep. No Gemini, no `channels:` required. |
 | "this video keeps getting re-transcribed", "fix identity-less metas", "backfill missing video_id", "meta.json has no video_id" | `repair-metas [--apply]` | **Dry-run first** (issue #66). Reconstructs `video_id`/`url`/`title`/`published` from the `.transcript.md` header for metas missing identity; only fills missing fields; refuses local/non-YouTube sources. Re-run `index --force` after `--apply`. |
 | "skip transcript on this video", "stop trying to transcribe [URL]", "this video keeps failing transcript", "block transcript only" | `mark-skip --url URL --mode transcript [--reason TEXT]` | Per-mode skip (issue #42). Mindmap and concepts continue to run. Repeatable: `--mode transcript --mode concepts`. |
 | "permanently ignore this video", "never re-process [video_id]", "skip these IDs on backfill", "stop touching this URL on every scan" | edit `skip_video_ids` under the channel in `config.yaml` | Declarative pre-fetch blocklist. Listed IDs never reach Gemini, never get a meta.json, no cost. Override = remove the ID from config. Cheaper than `mark-skip` since no meta.json roundtrip needed. |
@@ -485,6 +485,9 @@ python "${CLAUDE_SKILL_DIR}/../../scripts/video_intel.py" briefings --unseen
 
 # One-time backlog sweep: widen the window and raise the cap
 python "${CLAUDE_SKILL_DIR}/../../scripts/video_intel.py" briefings --unseen --since 120d --limit 60
+
+# Also write a clickable PDF beside the Markdown (needs the [pdf] extra)
+python "${CLAUDE_SKILL_DIR}/../../scripts/video_intel.py" briefings --unseen --pdf
 ```
 
 `briefings --unseen` surfaces corpus videos that appear in no existing
@@ -498,6 +501,14 @@ overlap with an inferred interest profile persisted at `_briefings/profile.yaml`
 (hand-edit to retune; never overwritten once it has content). No Gemini calls
 and no `channels:` config required. Writes `_briefings/<date>-catch-up-unseen.md`;
 `--dry-run` only prints the ranked unseen set.
+
+Pass `--pdf` to additionally write a clickable `_briefings/<date>-catch-up-unseen.pdf`
+rendered from the same ranked set: a one-page-friendly, shareable guide whose
+video titles and timestamped moments are bold, accent-colored hyperlinks that
+open YouTube at the exact second. The PDF is purely additive - the Markdown is
+always written and remains the seen-coverage record. Requires the optional
+`reportlab` dependency (`pip install -e ".[pdf]"`); without it the Markdown
+still writes and an install hint is logged.
 
 ### Extract and normalize concepts
 

--- a/tests/test_briefings_pdf.py
+++ b/tests/test_briefings_pdf.py
@@ -1,0 +1,97 @@
+"""Tests for the catch-up briefing PDF export (issue #82).
+
+The PDF renderer (`scripts/briefing_pdf.py`) is fed the SAME ranked set as the
+Markdown path and must produce a valid, clickable PDF: video titles and
+timestamped moments become live hyperlinks. reportlab + pypdf are optional, so
+these tests skip cleanly when they are not installed.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+pytest.importorskip("reportlab", reason="PDF export needs the optional [pdf] extra")
+pypdf = pytest.importorskip("pypdf", reason="link-annotation assertions need pypdf")
+
+from briefing_pdf import render_unseen_briefing_pdf  # noqa: E402
+
+LOWER, UPPER = date(2026, 6, 22), date(2026, 6, 25)
+PROFILE = {"id": "inferred-test"}
+
+
+def _ranked():
+    return [
+        {
+            "video_id": "r4_KLZvHoaA",
+            "title": "Anthropic Will Bring Back Fable 5 Differently",
+            "url": "https://www.youtube.com/watch?v=r4_KLZvHoaA",
+            "channel": "ramjad",
+            "published": "2026-06-25",
+            "score": 457,
+            "matched_concepts": ["Token Economics", "Model Selection Strategy"],
+        },
+        {
+            "video_id": "h1MxhfZSTjo",
+            "title": "Google Lost $2.7B In Talent",
+            "url": "https://www.youtube.com/watch?v=h1MxhfZSTjo",
+            "channel": "natebjones",
+            "published": "2026-06-22",
+            "score": 0,  # zero-score: no deep-links, mirrors the Markdown contract
+            "matched_concepts": [],
+        },
+    ]
+
+
+def _links(video):
+    # Mirror cmd_briefings: zero-score entries get no deep-links.
+    if not video.get("score"):
+        return []
+    return [("Weekly limits + credits (0:35)", f"{video['url']}&t=35s")]
+
+
+def test_pdf_written_with_clickable_links(tmp_path):
+    out = tmp_path / "brief.pdf"
+    render_unseen_briefing_pdf(_ranked(), PROFILE, out, lower=LOWER, upper=UPPER, link_extractor=_links)
+
+    assert out.exists() and out.stat().st_size > 0
+    reader = pypdf.PdfReader(str(out))
+    annots = sum(len(p.get("/Annots", [])) for p in reader.pages)
+    # 2 video-title links + 1 timestamp link (zero-score video contributes none).
+    assert annots >= 3, f"expected >=3 link annotations, got {annots}"
+
+
+def test_zero_score_video_has_no_deeplinks(tmp_path):
+    out = tmp_path / "brief.pdf"
+    render_unseen_briefing_pdf(_ranked(), PROFILE, out, lower=LOWER, upper=UPPER, link_extractor=_links)
+    text = "".join(p.extract_text() for p in pypdf.PdfReader(str(out)).pages)
+    # Both titles render; only the scored video shows a timestamp moment.
+    assert "Google Lost" in text
+    assert "0:35" in text
+
+
+def test_empty_ranked_set_does_not_crash(tmp_path):
+    out = tmp_path / "empty.pdf"
+    render_unseen_briefing_pdf([], PROFILE, out, lower=LOWER, upper=UPPER, link_extractor=_links)
+    assert out.exists()
+    assert len(pypdf.PdfReader(str(out)).pages) >= 1
+
+
+def test_markup_breaking_title_is_escaped(tmp_path):
+    """Creator-controlled titles with & or < must not corrupt the PDF markup."""
+    ranked = [
+        {
+            "video_id": "x",
+            "title": "C++ & <script> tricks for agents",
+            "url": "https://www.youtube.com/watch?v=x",
+            "channel": "test",
+            "published": "2026-06-24",
+            "score": 10,
+            "matched_concepts": [],
+        }
+    ]
+    out = tmp_path / "escape.pdf"
+    # Must not raise a reportlab parse error on the unescaped markup.
+    render_unseen_briefing_pdf(ranked, PROFILE, out, lower=LOWER, upper=UPPER, link_extractor=lambda v: [])
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
Closes #82.

## What this adds

`briefings --unseen --pdf` writes a clickable, shareable PDF beside the Markdown catch-up guide, rendered from the same ranked set. Video titles and timestamped moments are bold, accent-colored hyperlinks that open YouTube at the exact second, so the guide reads well on a phone and is easy to hand to someone else. One more gift in the box for anyone who installs the plugin.

```bash
pip install -e ".[pdf]"
python scripts/video_intel.py briefings --unseen --pdf
```

## How the design was chosen (a three-way bake-off)

The motivation was a hand-built PDF that looked good but wasn't reusable. Rather than guess, I rendered three candidates and compared them against this project's less-is-more rule:

| Candidate | Pages | Writer code | Links | Verdict |
|---|---|---|---|---|
| Minimal (stock styles) | 2 | ~40 lines | dead black text, no affordance | Fails "reasonably good results" |
| Polished | 3 | ~150 lines | bold + accent | Good, but bloated: recap section, nav tables, callout box, featured slot |
| **Lean (shipped)** | **1** | **~90 lines** | **bold + accent** | **Winner** |

The lean design keeps only the three things that turn a line of text into a call-to-action (bold, accent color, a real hyperlink) and drops everything else. The whole catch-up fits on one tappable page.

## Decisions resolved from the issue

- Vendor vs. personal-skill dependency: the writer is fully self-contained in `scripts/briefing_pdf.py` (reportlab only), decoupled from `video_intel.py` via a `link_extractor` callback. No dependency on any user-level skill, so it is reusable out of the box.
- No "featured video" slot: the top-ranked item simply renders first. A hard-coded featured slot would amplify keyword false-positives (a video that scores high on keywords but is off-topic).
- `--pdf` is purely additive: the Markdown is always written and remains the seen-coverage record (`load_seen_video_ids` parses `*.md` front matter only), so the issue #80 set-difference contract is untouched. This also sidesteps the "pdf-only run records video_ids" edge case entirely.
- `reportlab` is an optional extra (`[pdf]`); without it the Markdown still writes and an install hint is logged.

## Verification

- 938 tests pass; new `tests/test_briefings_pdf.py` asserts link annotations are embedded, zero-score videos get no deep-links, and empty / markup-breaking titles are handled.
- The shipped renderer was rendered with real mindmap deep-links and visually confirmed to be one page with bold accent hyperlinks.
- `ruff format` + `ruff check` clean.

## Reviewer note

This was built during an autonomous hand-off, so the design call (lean) was mine to make. It is intentionally easy to revert or restyle: all rendering lives in one ~90-line module behind one additive flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
