### PR TITLE
feat(briefings): general Markdown->clickable-PDF renderer (#84 slice 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ The `--pdf` flag is for reading on the go and sharing: it renders the ranked set
 
 `briefings --unseen` ranks deterministically; it is the candidate feed, not the final word. The richer, *curated* briefing - a named audience profile, a "watch these N" prioritization, pillar grouping, a "why it matters to you" line per video, and explicit signal/noise calls - is an editorial layer authored on top of that feed. See [`examples/catch-up-briefing-personalized-sample.pdf`](examples/catch-up-briefing-personalized-sample.pdf) for the target output; the curation layer that produces it directly is tracked in [#84](https://github.com/dzivkovi/video-intel/issues/84).
 
+Those curated briefings are free-form Markdown (authored per topic, not a fixed `ranked` shape), so they render through a general companion, [`scripts/markdown_pdf.py`](scripts/markdown_pdf.py) - the same bold/accent/hyperlink aesthetic as `briefing_pdf.py`, but for arbitrary Markdown. It strips a leading YAML front-matter block, keeps `[text](url)` and bare-URL links (including `&t=` deep-links) clickable even inside `**bold**` headers, and runs standalone:
+
+```bash
+python scripts/markdown_pdf.py _briefings/observability/2026-07-10-ai-observability-catchup.md out.pdf
+```
+
 ## Prompt Customization
 
 Prompts live in `prompts/`. Each file is self-contained.

--- a/scripts/markdown_pdf.py
+++ b/scripts/markdown_pdf.py
@@ -1,0 +1,171 @@
+"""General Markdown -> clickable-PDF renderer for curated briefings (issue #84).
+
+`briefing_pdf.py` renders the *structured* `ranked` dicts of a deterministic
+`briefings --unseen` run. This module is its free-form sibling: it turns an
+arbitrary **curated** Markdown briefing (the kind Claude authors in-session for
+a topic - profile, top picks, pillar sections, why-it-matters lines, signal/
+noise calls) into the SAME lean, tappable aesthetic: bold, one accent color,
+and real hyperlinks (including `&t=<seconds>` deep-links that open YouTube at
+the exact moment).
+
+Design mirrors `briefing_pdf.py` deliberately: reportlab is an OPTIONAL
+dependency (`pip install -e ".[pdf]"`), imported only when this module is used,
+and the same accent (`#c96442`) so every briefing PDF reads as one family.
+
+CLI:  python scripts/markdown_pdf.py INPUT.md OUTPUT.pdf
+API:  render_markdown_file_to_pdf(md_path, pdf_path)
+      render_markdown_to_pdf(md_text, pdf_path, title=...)
+
+Supported Markdown (briefing subset, not a full CommonMark parser):
+  #/##/### headings, --- rules, - and 1. bullets, **bold**, [text](url) links,
+  bare https:// URLs, and a leading `---`-fenced YAML front-matter block
+  (stripped - it is machine metadata, not reader content).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ACCENT = "#c96442"  # matches briefing_pdf.py - the one color that signals "clickable"
+
+# One pass tokenizes a line into markdown-link / bold / bare-URL / plain runs.
+# Plain runs are XML-escaped; URLs are escaped inside href too (reportlab
+# unescapes &amp; back to & when it follows the link), matching briefing_pdf._link.
+_INLINE = re.compile(
+    r"\[(?P<ltext>[^\]]+)\]\((?P<lurl>[^)]+)\)"  # [text](url)
+    r"|\*\*(?P<bold>[^*]+)\*\*"  # **bold**
+    r"|(?P<url>https?://[^\s)]+)"  # bare url
+)
+
+
+def _esc(text: str) -> str:
+    """Escape for reportlab's mini-markup parser (content is creator-controlled)."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _link(url: str, label: str) -> str:
+    return f'<a href="{_esc(url)}" color="{ACCENT}"><u>{_esc(label)}</u></a>'
+
+
+def _inline(text: str) -> str:
+    """Convert a single line's inline Markdown to reportlab markup, escaping the rest."""
+    parts: list[str] = []
+    pos = 0
+    for m in _INLINE.finditer(text):
+        if m.start() > pos:
+            parts.append(_esc(text[pos : m.start()]))
+        if m.group("ltext") is not None:
+            parts.append(_link(m.group("lurl"), m.group("ltext")))
+        elif m.group("bold") is not None:
+            # Recurse so a bold-wrapped link (**[Title](url)**, the header shape
+            # curated briefings use) stays clickable, not flattened to literal text.
+            parts.append(f"<b>{_inline(m.group('bold'))}</b>")
+        else:  # bare url
+            parts.append(_link(m.group("url"), m.group("url")))
+        pos = m.end()
+    if pos < len(text):
+        parts.append(_esc(text[pos:]))
+    return "".join(parts)
+
+
+def strip_front_matter(text: str) -> str:
+    """Drop a leading `---`-fenced YAML block (machine metadata, not content)."""
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            return text[end + 4 :].lstrip("\n")
+    return text
+
+
+def _build_story(md_text: str):
+    from reportlab.lib import colors
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.platypus import HRFlowable, Paragraph, Spacer
+
+    base = getSampleStyleSheet()
+    accent = colors.HexColor(ACCENT)
+    body = ParagraphStyle("md_body", parent=base["Normal"], fontSize=11, leading=15, spaceAfter=8)
+    bullet = ParagraphStyle("md_bullet", parent=body, leftIndent=14, spaceAfter=7)
+    h1 = ParagraphStyle("md_h1", parent=base["Title"], fontSize=18, leading=22, spaceBefore=6, spaceAfter=12)
+    h2 = ParagraphStyle(
+        "md_h2", parent=base["Heading2"], fontSize=14, leading=18, spaceBefore=14, spaceAfter=8, textColor=accent
+    )
+    h3 = ParagraphStyle("md_h3", parent=base["Heading3"], fontSize=12, leading=16, spaceBefore=10, spaceAfter=5)
+    meta = ParagraphStyle("md_meta", parent=body, fontSize=9.5, textColor=colors.HexColor("#555555"), spaceAfter=6)
+
+    story = []
+    for raw in md_text.split("\n"):
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        if line.startswith("### "):
+            story.append(Paragraph(_inline(line[4:]), h3))
+        elif line.startswith("## "):
+            story.append(Paragraph(_inline(line[3:]), h2))
+        elif line.startswith("# "):
+            story.append(Paragraph(_inline(line[2:]), h1))
+        elif line.strip() == "---":
+            story.append(Spacer(1, 4))
+            story.append(HRFlowable(width="100%", color=colors.HexColor("#cccccc"), thickness=0.6))
+            story.append(Spacer(1, 8))
+        elif re.match(r"^\d+\.\s", line) or line.startswith("- "):
+            story.append(Paragraph(_inline(re.sub(r"^(\d+\.\s|-\s)", "", line)), bullet))
+        elif line.startswith("**") and line.rstrip().endswith("**") and line.count("**") == 2:
+            story.append(Paragraph(_inline(line), meta))
+        else:
+            story.append(Paragraph(_inline(line), body))
+    return story
+
+
+def render_markdown_to_pdf(md_text: str, pdf_path, *, title: str | None = None) -> None:
+    """Render curated Markdown text to a clickable PDF at ``pdf_path``.
+
+    Raises ImportError (with the same install hint as briefing_pdf) if the
+    optional ``[pdf]`` extra is missing.
+    """
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.units import inch
+    from reportlab.platypus import SimpleDocTemplate
+
+    story = _build_story(strip_front_matter(md_text))
+    doc = SimpleDocTemplate(
+        str(pdf_path),
+        pagesize=letter,
+        topMargin=0.6 * inch,
+        bottomMargin=0.6 * inch,
+        leftMargin=0.55 * inch,
+        rightMargin=0.55 * inch,
+        title=title or Path(str(pdf_path)).stem,
+        author="video-intel",
+    )
+    doc.build(story)
+
+
+def render_markdown_file_to_pdf(md_path, pdf_path) -> None:
+    """Render a Markdown file to a clickable PDF beside it (or at ``pdf_path``)."""
+    text = Path(md_path).read_text(encoding="utf-8")
+    render_markdown_to_pdf(text, pdf_path, title=Path(str(md_path)).stem)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 2:
+        print("usage: python scripts/markdown_pdf.py INPUT.md OUTPUT.pdf", file=sys.stderr)
+        return 2
+    try:
+        render_markdown_file_to_pdf(argv[0], argv[1])
+    except ImportError:
+        print(
+            'PDF export needs reportlab. Install the optional extra: pip install -e ".[pdf]" '
+            "(or pip install reportlab).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Wrote {argv[1]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_markdown_pdf.py
+++ b/tests/test_markdown_pdf.py
@@ -1,0 +1,100 @@
+"""Tests for the general Markdown -> clickable-PDF renderer (issue #84, Slice 1).
+
+Companion to test_briefings_pdf.py. reportlab + pypdf are optional, so these
+skip cleanly when the [pdf] extra is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("reportlab", reason="PDF export needs the optional [pdf] extra")
+pypdf = pytest.importorskip("pypdf", reason="link-annotation assertions need pypdf")
+
+from markdown_pdf import (  # noqa: E402
+    _inline,
+    render_markdown_file_to_pdf,
+    render_markdown_to_pdf,
+    strip_front_matter,
+)
+
+SAMPLE = """---
+artifact_type: viewing_guide
+video_ids:
+  - abc
+---
+
+# Topic Briefing
+
+**Saved:** 2026-07-10
+
+## Top picks
+
+- [Great Talk (12:34)](https://www.youtube.com/watch?v=abc&t=754) - watch this
+- Plain bullet with a bare link https://example.com/x
+
+### 2024
+
+Some **bold** prose and a [second link](https://youtu.be/def).
+"""
+
+
+def test_strip_front_matter_removes_leading_yaml():
+    assert strip_front_matter(SAMPLE).startswith("# Topic Briefing")
+    # No front matter -> unchanged.
+    assert strip_front_matter("# No FM\nbody") == "# No FM\nbody"
+
+
+def test_inline_markdown_link_becomes_anchor_with_escaped_ampersand():
+    out = _inline("[Great Talk (12:34)](https://www.youtube.com/watch?v=abc&t=754)")
+    assert 'href="https://www.youtube.com/watch?v=abc&amp;t=754"' in out
+    assert "Great Talk (12:34)" in out
+
+
+def test_inline_bare_url_and_bold():
+    assert '<a href="https://example.com/x"' in _inline("see https://example.com/x now")
+    assert "<b>bold</b>" in _inline("some **bold** text")
+
+
+def test_inline_bold_wrapped_link_stays_clickable():
+    """Regression: `**[Title](url)**` (the curated-briefing header shape) must
+    render as a bold AND clickable link, not flattened to literal bold text."""
+    out = _inline("**[Sam - Must Haves](https://youtu.be/aIy85)** (2026-04-15)")
+    assert '<b><a href="https://youtu.be/aIy85"' in out
+    assert "Sam - Must Haves" in out
+    assert "[Sam" not in out  # the literal bracket must be gone (link was parsed)
+
+
+def test_inline_escapes_plain_text_specials():
+    # A stray & / < in prose must be escaped so reportlab does not choke.
+    out = _inline("A & B < C, no link here")
+    assert "&amp;" in out and "&lt;" in out
+    assert "<a " not in out  # nothing linkified
+
+
+def test_render_writes_pdf_with_clickable_links(tmp_path):
+    out = tmp_path / "brief.pdf"
+    render_markdown_to_pdf(SAMPLE, out)
+    assert out.exists() and out.stat().st_size > 0
+    reader = pypdf.PdfReader(str(out))
+    annots = sum(len(p.get("/Annots", [])) for p in reader.pages)
+    # 3 links: the timestamp deep-link, the bare url, and the second link.
+    assert annots >= 3, f"expected >=3 link annotations, got {annots}"
+    text = "".join(p.extract_text() for p in reader.pages)
+    assert "Topic Briefing" in text
+    # Front matter must NOT render into the body.
+    assert "artifact_type" not in text
+
+
+def test_render_file_roundtrip(tmp_path):
+    md = tmp_path / "in.md"
+    md.write_text(SAMPLE, encoding="utf-8")
+    out = tmp_path / "in.pdf"
+    render_markdown_file_to_pdf(md, out)
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_markup_breaking_title_does_not_crash(tmp_path):
+    out = tmp_path / "x.pdf"
+    render_markdown_to_pdf("# C++ & <script> in a heading\n\nbody & more", out)
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
First slice of #84 (the curation layer).

## Why

Curated topic briefings - the per-topic editorial guides (named profile, top picks, pillar sections, why-it-matters lines, signal/noise calls) - are free-form Markdown, not the structured `ranked` dicts that [`scripts/briefing_pdf.py`](https://github.com/dzivkovi/video-intel/blob/main/scripts/briefing_pdf.py) renders. Until now they were rendered to the clickable PDF by an **ephemeral scratchpad script that had to be recreated every session**. This promotes that renderer into the repo.

## What

[`scripts/markdown_pdf.py`](https://github.com/dzivkovi/video-intel/blob/main/scripts/markdown_pdf.py): a general Markdown -> clickable-PDF renderer in the **same** bold / accent (`#c96442`) / hyperlink aesthetic as `briefing_pdf.py`, so every briefing PDF reads as one family. Self-contained on the optional `[pdf]` extra (lazy reportlab import), importable, and runnable as a CLI:

```bash
python scripts/markdown_pdf.py _briefings/observability/2026-07-10-ai-observability-catchup.md out.pdf
```

Handles the briefing Markdown subset: `#`/`##`/`###` headings, `---` rules, `-` and `1.` bullets, `**bold**`, `[text](url)` + bare-URL links (including `&t=` deep-links), and strips a leading YAML front-matter block (machine metadata, not reader content).

## The one bug worth noting

Dogfooding the real observability briefing caught it: a **bold-wrapped link** (`**[Title](url)**` - the header shape curated briefings use) was being flattened to literal bold text, dropping the link (18 vs the scratchpad's 27 links). Fixed with recursive inline processing so bold content is re-parsed; a regression test locks it.

## Tests / scope

- 8 new tests in `tests/test_markdown_pdf.py` (front-matter strip, link/bold/bare-URL inline, the bold-wrapped-link regression, PDF render + clickable-annotation count, file roundtrip, markup-breaking input). 959 total pass; `ruff` clean.
- README updated to point at the renderer.
- This is deliberately just the **rendering primitive**. The rest of #84 - a prose audience-profile format, the in-session curation workflow, and a `briefings --topic` candidate generator - is specced in #84 (the script generates candidates + renders; the editorial judgment stays with the assistant in-session, per #84's model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)