### PR TITLE
P2: feat(briefings): curation contract - audience profile + in-session workflow (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ Those curated briefings are free-form Markdown (authored per topic, not a fixed 
 python scripts/markdown_pdf.py _briefings/observability/2026-07-10-ai-observability-catchup.md out.pdf
 ```
 
+The curation itself is authored **in-session by the assistant**, not scripted (the script has no reader context and makes no LLM call during triage). Two pieces make it repeatable: a hand-editable **audience profile** ([`examples/audience.md`](examples/audience.md) - copy it to `<output_dir>/_briefings/audience.md` and edit) that holds your standing pillars, current goals, and signal/noise calls (distinct from the machine-scored `profile.yaml`); and a documented **curation workflow** in the video-intel skill (read the profile → gather candidates via `search --vector` across several vocabulary angles → verify mindmaps and exact timestamps → author lens / watch-these-N / pillars / why-it-matters-to-you / signal-noise → render to `_briefings/<topic>/`). The `briefings --topic` convenience that scaffolds the candidate set is tracked in [#91](https://github.com/dzivkovi/video-intel/issues/91).
+
 ## Prompt Customization
 
 Prompts live in `prompts/`. Each file is self-contained.

--- a/examples/audience.md
+++ b/examples/audience.md
@@ -1,0 +1,48 @@
+<!--
+Audience Profile TEMPLATE (issue #84).
+
+This is the hand-edited READER CONTEXT that grounds *curated* topic briefings -
+the "why it matters to YOU" lines, the pillar grouping, and the signal/noise
+calls. It is prose for a human (and the assistant) to read, NOT the computed
+`profile.yaml` that ranks `briefings --unseen`. The two are deliberately
+separate: profile.yaml is machine-scored ranking input; this file is hand-edited
+narrative context.
+
+To use it: copy this file to `<output_dir>/_briefings/audience.md` in your
+corpus and edit it to describe yourself. It is never overwritten by any command;
+editing it is the whole point. Leave the placeholders you don't need.
+-->
+
+# Audience Profile
+
+**Persona:** solo AI-skills builder / independent consultant
+
+## Standing pillars
+
+The durable themes you want briefings organized around. Each becomes a "Pillar"
+section in a curated briefing (see `examples/catch-up-briefing-personalized-sample.pdf`).
+
+- **Pillar 1 - Agentic-coding craft & skills:** the tools and patterns I build with day to day; anything that sharpens how I ship.
+- **Pillar 2 - AI strategy & models:** model releases, capability shifts, and the economics that change what's worth building.
+- **Pillar 3 - Founder / consulting:** positioning, differentiation, and getting customers as a one-person business.
+
+## Current projects & goals
+
+What I'm actively building or trying to achieve right now. This is what a "why it
+matters to YOU" line is grounded in - a video matters because it moves one of these.
+
+- Shipping and selling a specific service/offer this quarter.
+- Standing out in a crowded market (differentiation over commodity execution).
+- Learning the sell/market/get-customers side, not just the build side.
+
+## What counts as signal
+
+- Concrete mechanisms with numbers, not vibes: pricing, funnel math, real tradeoffs.
+- Techniques I can apply this week, or frameworks that change how I decide.
+- Contrarian or non-obvious takes from practitioners who actually shipped.
+
+## What counts as noise (skim or skip)
+
+- Hype, "me-too" reaction videos, and promotional tool tours with no substance.
+- Topics outside my pillars, however popular.
+- Restated basics I already know.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dev = [
     "ruff",
     "pytest",
     "pytest-cov",
+    # PDF test deps: without these, the briefing/markdown PDF tests silently
+    # importorskip on a clean dev install and their strongest assertions
+    # (clickable-link counts, sample-structure drift guard) never run.
+    "reportlab>=4",
+    "pypdf",
 ]
 
 [tool.ruff]

--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -145,6 +145,7 @@ table is the canonical mapping — read it before picking a command.
 | "prune shorts", "remove shorts", "too many shorts in my corpus" | `prune-shorts [--apply]` | **Always `--dry-run` first** — destructive on `--apply`; deletes mindmap/transcript/concepts/meta per Short |
 | "rebuild taxonomy", "update master vocabulary" | `taxonomy-build` | Derived artifact; rebuildable anytime |
 | "catch me up on what I missed", "what haven't I been briefed on", "videos I haven't seen yet", "generate a catch-up briefing", "fill the gaps in my viewing guides", "give me the briefing as a PDF", "a briefing I can open on my phone / share" | `briefings --unseen [--dry-run] [--since DATE] [--until DATE] [--limit N] [--pdf]` | Surfaces corpus videos absent from every existing `_briefings/**/*.md` `video_ids` list, including topic subfolders like `_briefings/sales/` (strict set difference, never re-surfaced once briefed), **across the whole corpus by default (no recency floor)**, ranked by relevance overlap with the inferred profile in `_briefings/profile.yaml` and capped to the top `N` (default 30; `--limit 0` = no cap). Each entry shows an age badge (`age 3y`) and a "By year" appendix regroups the same set chronologically. `--dry-run` previews; otherwise writes `_briefings/<date>-catch-up-unseen.md`. `--pdf` additionally writes a clickable `.pdf` beside it (bold, accent-colored, hyperlinked timestamps; needs the `[pdf]` extra). Pass `--since 30d` (or any date) to *narrow* to a recency floor. No Gemini, no `channels:` required. |
+| "build me a briefing on **[topic]**", "what should I know about X", "catch me up on **[topic]**", "make me a curated guide on Y" (a **specific topic**, not the deterministic unseen catch-up) | *In-session curation workflow* (see "Curated topic briefing" below) | NOT a single command. Read `_briefings/audience.md`, gather candidates via `search --vector` across several vocabulary angles, verify mindmaps + exact timestamps, author the editorial structure (lens, watch-these-N, pillars, why-it-matters-to-you, signal/noise) with a `video_ids:` front matter, write to `_briefings/<topic>/`, render with `scripts/markdown_pdf.py`. The assistant authors the judgment; the scripts only supply candidates + render. |
 | "this video keeps getting re-transcribed", "fix identity-less metas", "backfill missing video_id", "meta.json has no video_id" | `repair-metas [--apply]` | **Dry-run first** (issue #66). Reconstructs `video_id`/`url`/`title`/`published` from the `.transcript.md` header for metas missing identity; only fills missing fields; refuses local/non-YouTube sources. Re-run `index --force` after `--apply`. |
 | "skip transcript on this video", "stop trying to transcribe [URL]", "this video keeps failing transcript", "block transcript only" | `mark-skip --url URL --mode transcript [--reason TEXT]` | Per-mode skip (issue #42). Mindmap and concepts continue to run. Repeatable: `--mode transcript --mode concepts`. |
 | "permanently ignore this video", "never re-process [video_id]", "skip these IDs on backfill", "stop touching this URL on every scan" | edit `skip_video_ids` under the channel in `config.yaml` | Declarative pre-fetch blocklist. Listed IDs never reach Gemini, never get a meta.json, no cost. Override = remove the ID from config. Cheaper than `mark-skip` since no meta.json roundtrip needed. |
@@ -525,6 +526,55 @@ open YouTube at the exact second. The PDF is purely additive - the Markdown is
 always written and remains the seen-coverage record. Requires the optional
 `reportlab` dependency (`pip install -e ".[pdf]"`); without it the Markdown
 still writes and an install hint is logged.
+
+### Curated topic briefing (the editorial layer, authored in-session)
+
+`briefings --unseen` is the *deterministic candidate feed*. A **curated topic
+briefing** - the kind a user means by "build me a briefing on AI observability"
+or "what should I know about X" - is the richer editorial artifact you (the
+assistant) author in-session. The script never authors this judgment: it has no
+reader context and does not call an LLM during triage. Your job is the curation;
+the committed scripts only supply candidates and render.
+
+Route a "briefing / catch me up / what should I know about **a specific topic**"
+request (as opposed to the deterministic unseen catch-up) to this workflow:
+
+1. **Read the reader context.** If `<output_dir>/_briefings/audience.md` exists,
+   read it - its standing pillars, current goals, and signal/noise calls are what
+   ground the "why it matters to YOU" lines. (Template: `examples/audience.md`.)
+   **If it does NOT exist, do not invent the reader's goals.** Either ask the user
+   for their pillars/priorities (and offer to save them as `audience.md`), or fall
+   back to *topical* relevance - a "why it matters" line grounded only in the
+   video's own content, not a fabricated personalization - and say so. Never
+   manufacture "matters to YOU because you're working on X" without a real source.
+2. **Gather candidates via hybrid search.** Run `search "<angle>" --vector`
+   across several *vocabulary angles* for the topic (creators rarely use the
+   user's exact term - see the observability example: they say "tracing,"
+   "telemetry," "agent analytics," not "observability"). A video surfacing under
+   multiple angles is a strong signal.
+3. **Verify before you cite.** Read the matched `*.mindmap.md` files to confirm
+   each is genuinely on-topic and to copy **exact** timestamps. Drop title-similar
+   results that turn out off-topic; mark honest `core` vs `peripheral`.
+4. **Author the editorial structure** (match `examples/catch-up-briefing-personalized-sample.pdf`):
+   an intro/lens line, a "watch these N" top-picks section, `## Pillar` groupings
+   from `audience.md`, a why-it-matters-to-you line per item grounded in the
+   mindmap + reader context, and an explicit signal/noise ("skim or skip",
+   "explicitly excluded") section. Put a `video_ids:` front-matter list at the top
+   so the briefing counts toward the seen-set.
+5. **Render + place.** Write the Markdown into `_briefings/<topic>/` (a topic
+   subfolder), then render the clickable PDF beside it:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/../../scripts/markdown_pdf.py" _briefings/<topic>/<file>.md _briefings/<topic>/<file>.pdf
+   ```
+
+   `markdown_pdf.py` gives curated briefings the same bold/accent/hyperlink
+   aesthetic as the `--pdf` flag, and keeps `[text](url)` + `&t=` deep-links
+   clickable even inside `**bold**` headers.
+
+Do NOT fabricate "why it matters" prose from the deterministic ranking alone -
+that line requires the reader context in `audience.md`, which is the whole point
+of keeping it separate from the machine-scored `profile.yaml`.
 
 ### Extract and normalize concepts
 

--- a/tests/test_briefing_curation_docs.py
+++ b/tests/test_briefing_curation_docs.py
@@ -1,0 +1,72 @@
+"""Sample-driven doc tests for the curated-briefing contract (issue #84, Slice 2).
+
+The curation layer is prose + skill routing, not triage code - but the contract
+still needs guarding so the audience-profile template, the documented in-session
+workflow, and the committed reference sample cannot silently drift apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+AUDIENCE = REPO / "examples" / "audience.md"
+SKILL = REPO / "skills" / "video-intel" / "SKILL.md"
+SAMPLE_PDF = REPO / "examples" / "catch-up-briefing-personalized-sample.pdf"
+
+
+def test_audience_template_exists_with_required_sections():
+    """The hand-editable prose profile template must document its four surfaces."""
+    text = AUDIENCE.read_text(encoding="utf-8").lower()
+    assert "persona" in text
+    assert "standing pillars" in text
+    assert "signal" in text
+    assert "noise" in text
+    # It must call out that it is separate from the machine-scored profile.yaml.
+    assert "profile.yaml" in text
+
+
+def test_skill_documents_the_curation_workflow():
+    """SKILL.md must route topic briefings to the in-session workflow and keep
+    the boundary explicit (assistant curates; scripts supply candidates + render)."""
+    text = SKILL.read_text(encoding="utf-8")
+    assert "Curated topic briefing" in text
+    assert "audience.md" in text
+    assert "markdown_pdf.py" in text  # the render step
+    assert "search" in text and "--vector" in text  # candidate gathering
+    # The boundary: the script must not fabricate the editorial judgment.
+    lowered = text.lower()
+    assert "does not call an llm during triage" in lowered or "never authors this judgment" in lowered
+
+
+def test_skill_documents_missing_audience_fallback():
+    """A future assistant must not fabricate reader context when audience.md is
+    absent - the workflow has to name the fallback explicitly (Codex review)."""
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "does not exist" in text or "if it does not exist" in text
+    assert "do not invent" in text or "never manufacture" in text
+
+
+def test_sample_pdf_shows_the_promised_structure():
+    """The committed reference sample must still contain the structural markers
+    the workflow promises, so the doc and the example can't drift. `pypdf` is in
+    the `dev` extra, so this runs (not silently skips) on a normal dev install."""
+    pypdf = pytest.importorskip("pypdf", reason="reading the sample PDF needs pypdf")
+    text = " ".join(p.extract_text() for p in pypdf.PdfReader(str(SAMPLE_PDF)).pages).lower()
+    for marker in ("watch these", "pillar", "skim or skip"):
+        assert marker in text, f"sample PDF is missing the promised structural marker: {marker!r}"
+    # Cross-consistency: the SKILL workflow must actually promise the same
+    # structural vocabulary the sample demonstrates, so doc and example can't drift.
+    skill = SKILL.read_text(encoding="utf-8").lower()
+    assert "watch these" in skill
+    assert "pillar" in skill
+    assert "signal/noise" in skill or "skim or skip" in skill
+
+
+def test_audience_template_has_no_client_or_pii_leakage():
+    """The committed template must stay generic - it ships publicly."""
+    text = AUDIENCE.read_text(encoding="utf-8").lower()
+    for banned in ("mastercard", "@gmail", "ciklum", "magma inc"):
+        assert banned not in text, f"committed audience template leaks '{banned}'"


### PR DESCRIPTION
Closes #84 (the rescoped curation-layer contract). Third and final piece of the briefings-curation arc, after #90 (the render primitive) and alongside #91 (the `briefings --topic` scaffold, split out).

## What

The curation **layer** - the "brain" behind curated topic briefings - as prose + skill routing + doc tests. No new triage code (per #84's boundary: the assistant authors editorial judgment in-session; scripts only supply candidates + render).

- **[`examples/audience.md`](https://github.com/dzivkovi/video-intel/blob/main/examples/audience.md)** - a committed, generic template for a hand-editable prose **audience profile** (persona, standing pillars, current goals, signal/noise). It grounds the "why it matters to YOU" lines and the pillar grouping, and is kept deliberately separate from the machine-scored `profile.yaml` (the ranking input for `--unseen`). Copy to `<output_dir>/_briefings/audience.md` and edit.
- **[`skills/video-intel/SKILL.md`](https://github.com/dzivkovi/video-intel/blob/main/skills/video-intel/SKILL.md)** - a routing row + a "Curated topic briefing" workflow: read `audience.md` → gather candidates via `search --vector` across several vocabulary angles → verify mindmaps + exact timestamps → author the editorial structure (lens, watch-these-N, `## Pillars`, why-it-matters-to-you, signal/noise) with `video_ids:` front matter → write to `_briefings/<topic>/` → render via `scripts/markdown_pdf.py`. Explicit **missing-`audience.md` fallback** so a future assistant asks for context or falls back to topical relevance rather than fabricating personalization.
- **README** updated; **tests** guard the contract (template sections, no client/PII leak, separate-from-`profile.yaml`; SKILL documents the workflow + the no-LLM-in-triage boundary + the fallback; the committed reference sample PDF still shows the promised structure so doc and example can't drift).
- **pyproject**: `reportlab` + `pypdf` added to the `dev` extra so the PDF-verification tests actually run on a clean dev install instead of silently `importorskip`-ing.

## Review

Design and implementation both reviewed via the real Codex CLI (proxying for the maintainer, who was asleep). Codex's verdict was "merge with follow-up fixes"; all three folded in before this PR:
- missing-`audience.md` fallback documented in the workflow;
- the silently-skipped PDF drift guard fixed by adding `pypdf` to the `dev` extra;
- a doc/sample cross-consistency guard so the SKILL workflow and the reference sample can't drift.

964 tests pass; `ruff` clean. Only the 5 intended files are in this PR (an unrelated untracked brainstorm note was deliberately left out, per the review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)