### PR TITLE
P2: docs(intelligence): DuckDB store exploration guide, drop neo4j extra, fix editable install (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,60 @@ See [ADR-0012](docs/adr/ADR-0012-vector-search-lancedb-voyage.md) for
 embedding choices and [ADR-0013](docs/adr/ADR-0013-hybrid-search-rrf-fusion.md)
 for the hybrid search decision. Evaluation queries in `evals/`.
 
+## Exploring the Intelligence Store (optional)
+
+Beyond search, the repo can build a small **DuckDB analytics store** from your existing corpus artifacts - a queryable database of who said what, when, about which concepts. Everything here is optional: the scan/transcript/search workflow above never touches it.
+
+### Install the two layers (they are different things)
+
+The Python package and the interactive CLI are **separate installs** - `pip install duckdb` gives Python scripts a driver but does NOT put a `duckdb` command on your PATH:
+
+```bash
+# 1. Python layer - lets the analysis scripts run
+pip install -e ".[intelligence]"
+
+# 2. CLI + local notebook UI - a separate binary
+winget install DuckDB.cli      # Windows
+brew install duckdb            # macOS
+curl https://install.duckdb.org | sh   # Linux
+```
+
+### Build and explore the store
+
+```bash
+# Build (read-only over your corpus; writes ~/.cache/video-intel/intel.duckdb)
+python scripts/intel_graph.py load
+
+# Open the local notebook UI in your browser (pass -readonly: the scripts
+# expect to be the only writer)
+duckdb -readonly -ui ~/.cache/video-intel/intel.duckdb
+```
+
+The UI is a local notebook (nothing leaves your machine): browse tables, run SQL, export CSV for spreadsheet work.
+
+### What is in it
+
+The 6-node / 6-edge starter schema. Node tables: `sources` (channels), `artifacts` (videos, with `published_at`), `segments` (transcript chunks), `concepts` (normalized taxonomy concepts), `entities` (surface terms), `mentions` (term occurrences with timestamps). Edge tables connect them: `has_segment`, `has_concept` (video -> concept), `about`, `expresses` (claim -> verbatim quote + timestamp), `claims`, `published`, `co_occurs`. Try:
+
+```sql
+-- which channels cover a concept, in order of first coverage
+SELECT a.source_id, min(a.published_at::DATE) AS first_covered
+FROM has_concept hc JOIN artifacts a USING (artifact_id)
+WHERE hc.concept_id = 'ai-engineering.context_engineering'
+GROUP BY a.source_id ORDER BY first_covered;
+```
+
+### Ready-made analyses over the store
+
+- `python scripts/lead_lag_report.py` - coverage-corrected "who covers a concept first, who follows" ranking with evidence links.
+- `python scripts/lead_lag_viz.py --out report.html` - the same statistics as one self-contained interactive HTML.
+- `python scripts/burst_report.py` - Kleinberg burst detection: which concepts just caught fire, with start dates and intensity.
+- `python scripts/wiki_atlas.py --wiki-dir <output_dir>/_wiki` - generate an Obsidian-readable creator/concept atlas from the lead-lag data.
+
+All four are read-only against the store and print to stdout or a file you choose. The store itself is a derived artifact - delete it any time and rebuild with `load`.
+
+> Note: the experimental `intel_graph.py project` / `verify` subcommands (Neo4j community-detection R&D) need a Neo4j server and the driver, which is no longer part of the `[intelligence]` extras: `pip install neo4j` manually if you want that path. The analyses above do not need it.
+
 ## Cost
 
 Using Gemini 3 Flash ($0.50/M input tokens, $1.00/M audio, $3.00/M output):

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ The UI is a local notebook (nothing leaves your machine): browse tables, run SQL
 
 ### What is in it
 
-The 6-node / 6-edge starter schema. Node tables: `sources` (channels), `artifacts` (videos, with `published_at`), `segments` (transcript chunks), `concepts` (normalized taxonomy concepts), `entities` (surface terms), `mentions` (term occurrences with timestamps). Edge tables connect them: `has_segment`, `has_concept` (video -> concept), `about`, `expresses` (claim -> verbatim quote + timestamp), `claims`, `published`, `co_occurs`. Try:
+The 6-node / 6-edge starter schema. Node tables: `sources` (channels), `artifacts` (videos, with `published_at`), `segments` (transcript chunks), `concepts` (normalized taxonomy concepts), `entities` (surface terms), `claims` (extracted statements). Relationship tables connect them: `published` (source -> artifact), `has_segment`, `mentions` (segment -> entity, with timestamps), `has_concept` (video -> concept), `about`, `expresses` (claim -> verbatim quote + timestamp), plus the derived `co_occurs` (`projection_meta` is internal bookkeeping). Try:
 
 ```sql
 -- which channels cover a concept, in order of first coverage

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,7 @@ This table doubles as the project's **failure-mode registry**: the **Status** co
 | Two mindmaps / metas for one video | **Title rotation** (A/B SEO) | `dedupe` (dry-run first) | manual (run `dedupe`) |
 | Same video re-transcribed every scan; `meta.json` has no `video_id` | **Identity-less meta** (transcript writer was first and didn't stamp identity) | prevented going forward (writers stamp identity); `repair-metas --apply` heals existing ones | auto (#66) + `repair-metas` for old data |
 | An already-done video is re-queued mid-scan though its artifacts are on disk (corpus on Google Drive File Stream) | **Cloud-mount read-after-write staleness** - the mount serves a cached pre-write `meta.json` to the scanning process | accepted environmental constraint; impact is bounded to wasted re-transcription (no hang/corruption) since #66/#74. See the scenario below | documented (#67) - blunted by #66/#74 |
+| `duckdb: command not found` after `pip install -e ".[intelligence]"` | **The CLI is a separate binary** - the pip package is only the Python driver | `winget install DuckDB.cli` (Windows) / `brew install duckdb` (macOS), then `duckdb -readonly -ui ~/.cache/video-intel/intel.duckdb`; see README "Exploring the Intelligence Store" | manual (#102) |
 
 ## Scenarios
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ pdf = [
     "reportlab>=4",
 ]
 intelligence = [
+    # neo4j deliberately absent: issue #95 retired Neo4j/GDS as the analytics
+    # engine. The experimental intel_graph.py project/verify subcommands name
+    # the manual `pip install neo4j` in their error message instead.
     "duckdb>=1.0",
-    "neo4j>=5",
 ]
 dev = [
     "ruff",
@@ -32,6 +34,16 @@ dev = [
     "reportlab>=4",
     "pypdf",
 ]
+
+[tool.setuptools]
+# This repo is a plugin of standalone scripts, not an importable package:
+# nothing under scripts/ is meant to be site-packages-installed. Without
+# this, setuptools flat-layout auto-discovery sees the plugin's top-level
+# folders (skills/, prompts/, evals/, ...) as "multiple packages" and every
+# documented `pip install -e ".[extra]"` fails on a fresh clone (found
+# testing issue #102). Empty packages = install registers dependencies and
+# metadata only, which is exactly the intent.
+packages = []
 
 [tool.ruff]
 line-length = 120

--- a/scripts/intel_graph.py
+++ b/scripts/intel_graph.py
@@ -108,7 +108,9 @@ def require_neo4j():
 
         return GraphDatabase
     except ImportError:
-        log.error("neo4j driver not installed. Run: pip install 'video-intel[intelligence]'")
+        # not in the [intelligence] extras: #95 retired Neo4j/GDS as the
+        # analytics engine, so this experimental path is a manual install
+        log.error("neo4j driver not installed. Run: pip install neo4j (plus a running Neo4j server)")
         sys.exit(1)
 
 

--- a/skills/video-intel/SKILL.md
+++ b/skills/video-intel/SKILL.md
@@ -109,6 +109,8 @@ pip install lancedb voyageai
 
 If prerequisites are missing, tell the user what's needed and where to get it.
 
+For ad-hoc analytics over the corpus (who covered a concept first, what is bursting), point the user at the optional DuckDB intelligence store - see "Exploring the Intelligence Store" in the repo README for install (`pip install -e ".[intelligence]"` plus the separate `duckdb` CLI binary) and the ready-made analysis scripts.
+
 ## Important: These Commands Are Slow
 
 Gemini API calls read video frames and audio — they take **1-5 minutes per video**. A scan of 10 videos can take 10-30 minutes. This is normal.


### PR DESCRIPTION
Closes #102.

## What

1. **README section 'Exploring the Intelligence Store'** - written for strangers: the pip-package-vs-CLI-binary distinction (the original failure), per-OS CLI install, `duckdb -readonly -ui`, what the 6-node/6-edge tables hold, one example SQL query, and the four ready-made analyses (lead-lag report/viz, bursts, wiki atlas).
2. **`pyproject.toml`: neo4j dropped from `[intelligence]`** per the #95 retirement; `intel_graph.py`'s `require_neo4j` error now names the manual `pip install neo4j`.
3. **SKILL.md pointer** in the curate skill only - the read-only search skill stays DuckDB-free (decision recorded in #102: document, don't couple).
4. **Troubleshooting row** for `duckdb: command not found`.
5. **Bonus, found by actually testing: editable install was broken for the world.** `pip install -e ".[intelligence]"` (and every other documented extra) fails on a fresh clone - setuptools flat-layout auto-discovery sees `skills/`, `prompts/`, `evals/` etc. as 'multiple top-level packages' and aborts. Fixed with `[tool.setuptools] packages = []` (this repo is standalone scripts; nothing belongs in site-packages).

## Gate 1 (real environment, not just prose)

- `winget install DuckDB.cli` -> v1.5.4 installed; `duckdb -readonly` queried the real store (14 tables listed); `duckdb -readonly -ui` served the notebook UI (HTTP 200 on :4213).
- `pip install -e ".[intelligence]"`: failed before the pyproject fix (output captured), succeeds after; `.[dev,vector,pdf,intelligence]` also verified, all extras import.
- `python scripts/intel_graph.py verify` runs against the real store post-install.

## Premise-dependent claims

- `packages = []` assumes nothing imports this project from site-packages (all tests/scripts use checkout-relative paths via conftest `pythonpath`); falsifier: any future console-script entry point would need explicit py-modules instead.

Tests: full suite green. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)